### PR TITLE
[Fix]:issue of parsing nan

### DIFF
--- a/pygwalker/gwalker.py
+++ b/pygwalker/gwalker.py
@@ -3,7 +3,7 @@ from .base import *
 global_gid = 0
 
 def to_records(df: pd.DataFrame):
-    
+    df = df.replace({float('nan'): None})
     return df.to_dict(orient='records')
 
 def raw_fields(df: pd.DataFrame):
@@ -62,7 +62,8 @@ class DataFrameEncoder(json.JSONEncoder):
 def render_gwalker_js(gid: int, props: tp.Dict):
     walker_template = jinja_env.get_template("walk.js")
     js = walker_template.render(gwalker={'id': gid, 'props': json.dumps(props, cls=DataFrameEncoder)} )
-    return gwalker_script() + js
+    js = gwalker_script() + js
+    return js
     
 def walk(df: pd.DataFrame, gid: tp.Union[int, str]=None, **kwargs):
     """walk through pandas.DataFrame df with Graphic Walker


### PR DESCRIPTION
`pd.DataFrame.to_dict` keeps NaN values as `float('nan')` and `json.dumps`  handles the transformation of numbers directly instead of delegating to a `json.JSONEncoder` class. Then the json output contains 'nan' which cannot be handled by javascript's `JSON.parse`.

Our solution is replacing NaN's in DataFrames with `None`, which leads to a standard `'null'` in json.