### PR TITLE
[windows]Open templates in utf8 encoding

### DIFF
--- a/pygwalker/base.py
+++ b/pygwalker/base.py
@@ -11,7 +11,7 @@ gwalker_js = None
 def gwalker_script():
     global gwalker_js
     if gwalker_js is None:
-        with open(os.path.join(HERE, 'templates', 'graphic-walker.iife.js'), 'r') as f:
+        with open(os.path.join(HERE, 'templates', 'graphic-walker.iife.js'), 'r', encoding='utf8') as f:
             gwalker_js = "const exports={};const process={env:{NODE_ENV:\"production\"} };" + f.read()
     return gwalker_js
         


### PR DESCRIPTION
Fixes Windows + JupyterLab combination.

Without this fix, `pyg.walk(df)` throws: `'charmap' codec can't decode byte 0x8d in position 511737: character maps to <undefined>`