### PR TITLE
[Feat]: Dump dataSource in tight mode to reduce .ipynb file size.

### DIFF
--- a/pygwalker/gwalker.py
+++ b/pygwalker/gwalker.py
@@ -59,13 +59,13 @@ class GWalker:
     def update(self, df: pd.DataFrame=None, **kwargs):
         pass
     
-    @property
-    def dataSource(self) -> tp.List[tp.Dict]:
-        from .utils.gwalker_props import to_records
-        return to_records(self.df)
+    # @property
+    # def dataSource(self) -> tp.List[tp.Dict]:
+    #     from .utils.gwalker_props import to_records
+    #     return to_records(self.df)
     
-    @property
-    def rawFields(self) -> tp.List:
-        from .utils.gwalker_props import raw_fields
-        return raw_fields(self.df)
+    # @property
+    # def rawFields(self) -> tp.List:
+    #     from .utils.gwalker_props import raw_fields
+    #     return raw_fields(self.df)
     

--- a/pygwalker/templates/walk.js
+++ b/pygwalker/templates/walk.js
@@ -1,6 +1,7 @@
 try{
 var gw_id = "gwalker-{{ gwalker.id }}";
 var props = {{ gwalker.props }};
+props.dataSource = props.dataSource.data.map(record => props.dataSource.columns.map((col, i) => ({ [col]: i })));
 console.log(props, gw_id);
 GraphicWalker.GWalker(props, gw_id);
 }catch(e){ console.error(e); }

--- a/pygwalker/utils/gwalker_props.py
+++ b/pygwalker/utils/gwalker_props.py
@@ -35,7 +35,7 @@ def infer_prop(s: pd.Series, i=None) -> tp.Dict:
     
 def to_records(df: pd.DataFrame):
     df = df.replace({float('nan'): None})
-    return df.to_dict(orient='records')
+    return df.to_dict(orient='tight')
 
 def raw_fields(df: pd.DataFrame):
     return [


### PR DESCRIPTION
using `df.to_dict` with `orient='tight'` instead of `orient='records'`

