### PR TITLE
Add DataCamp Workspace to list of supported environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Visit [Google Colab](https://colab.research.google.com/drive/171QUQeq-uTLgSj1u-P
 - [x] Hex Projects (Since version `0.1.4a0`)
 - [x] Most web applications compatiable with IPython kernels. (Since version `0.1.4a0`)
 - [x] **Streamlit (Since version `0.1.4.9`)**, enabled with `pyg.walk(df, env='Streamlit')`
+- [x] DataCamp Workspace (Since version `0.1.4a0`)
 - [ ] ...feel free to raise an issue for more environments.
 
 <table>


### PR DESCRIPTION
DataCamp Workspace recently added support for PyGWalker. We'd really appreciate being included in the list.

You can find an example workspace here:
- [Workspace](https://app.datacamp.com/workspace/w/2488c45a-08b3-452b-ba37-ebaf3991ab08/edit)
- [Publication](https://app.datacamp.com/workspace/w/2488c45a-08b3-452b-ba37-ebaf3991ab08)

Thank you!