### PR TITLE
[Feat]: Allows to serialize all Python classes with __str__ method

### DIFF
--- a/pygwalker/utils/render.py
+++ b/pygwalker/utils/render.py
@@ -18,8 +18,10 @@ jinja_env = Environment(
 
 class DataFrameEncoder(json.JSONEncoder):
     def default(self, obj):
-        if isinstance(obj, (datetime.datetime,datetime.date,datetime.time)):
+        try:
             return str(obj)
+        except TypeError:
+            pass
         return json.JSONEncoder.default(self, obj)
 
 def render_gwalker_html(gid: int, props: tp.Dict):


### PR DESCRIPTION
I did have some issues with Python objects which were previously not serializable with the current `DataFrameEncoder`. 
This PR allows all objects serializable to a String to be encoded to JSON, including the previous special cases for `datetime`.