### PR TITLE
fix: remove data restrictions for non-Jupyter env

### DIFF
--- a/pygwalker/utils/gwalker_props.py
+++ b/pygwalker/utils/gwalker_props.py
@@ -106,7 +106,13 @@ class DataFramePropGetter(tp.Generic[DataFrame]):
     
     @classmethod
     def get_props(cls, df: DataFrame, **kwargs):
-        df = cls.limited_sample(df)
+        """Remove data volume restrictions for non-JUPyter environments.
+
+        Kargs:
+            - env: (Literal['Jupyter' | 'Streamlit'], optional): The enviroment using pygwalker from program entry. Default as 'Jupyter'
+        """
+        if kwargs.get('env') == 'Jupyter':
+            df = cls.limited_sample(df)
         df = cls.escape_fname(df, **kwargs)
         props = {
             'dataSource': cls.to_records(df),


### PR DESCRIPTION
issue#125：
user can not load more data in stream because the limit in jupyter equally valid in streamlit env, but streamlit environments are not limited by ipynb.
The jupyter environment can be directly distinguished by the parameters.