### PR TITLE
fix: missing error cases for temporal type infer

### DIFF
--- a/pygwalker/data_parsers/base.py
+++ b/pygwalker/data_parsers/base.py
@@ -125,7 +125,7 @@ def is_geo_field(field_name: str) -> bool:
     field_name = field_name.lower().strip(" .")
     return field_name in {
         "latitude", "longitude",
-        "lat", "long",
+        "lat", "long", "lon"
     }
 
 

--- a/pygwalker/data_parsers/base.py
+++ b/pygwalker/data_parsers/base.py
@@ -115,7 +115,7 @@ def is_temporal_field(value: str) -> bool:
     """check if field is temporal"""
     try:
         arrow.get(value)
-    except arrow.parser.ParserError:
+    except:
         return False
     return True
 

--- a/pygwalker/data_parsers/database_parser.py
+++ b/pygwalker/data_parsers/database_parser.py
@@ -13,6 +13,7 @@ import sqlglot
 from .base import BaseDataParser
 from .pandas_parser import PandasDataFrameDataParser
 from pygwalker.data_parsers.base import FieldSpec
+from decimal import Decimal
 
 logger = logging.getLogger(__name__)
 
@@ -60,10 +61,13 @@ class DatabaseDataParser(BaseDataParser):
     }
 
     def __init__(self, conn: Connector, _: bool, field_specs: Dict[str, FieldSpec]):
-        self.conn = conn
+        self.conn = conn        
         self.example_pandas_df = pd.DataFrame(
             self.conn.query_datas(f"SELECT * FROM {self.conn.view_name} LIMIT 1000")
         )
+        for column in self.example_pandas_df.columns:
+            if any(isinstance(val, Decimal) for val in self.example_pandas_df[column]):
+                self.example_pandas_df[column] = self.example_pandas_df[column].astype(float)
         self.field_specs = field_specs
 
     @property

--- a/pygwalker/data_parsers/modin_parser.py
+++ b/pygwalker/data_parsers/modin_parser.py
@@ -53,13 +53,13 @@ class ModinPandasDataFrameDataParser(BaseDataFrameDataParser[mpd.DataFrame]):
         example_value = s[0]
         kind = s.dtype.kind
 
-        if (kind in "fcmiu" and v_cnt > 16) or is_geo_field(field_name):
+        if (kind in "fcmiu" and v_cnt > 2) or is_geo_field(field_name):
             return "quantitative"
         if kind in "M" or (kind in "bOSUV" and is_temporal_field(str(example_value))):
-            return "temporal"
-        if kind in "bOSUV" or v_cnt <= 2:
-            return "nominal"
-        return "ordinal"
+            return 'temporal'
+        if kind in "iu":
+            return "ordinal"
+        return "nominal"
 
     def _infer_analytic(self, s: mpd.Series, field_name: str):
         kind = s.dtype.kind

--- a/pygwalker/data_parsers/pandas_parser.py
+++ b/pygwalker/data_parsers/pandas_parser.py
@@ -46,14 +46,13 @@ class PandasDataFrameDataParser(BaseDataFrameDataParser[pd.DataFrame]):
         v_cnt = len(s.value_counts())
         example_value = s[0]
         kind = s.dtype.kind
-
-        if (kind in "fcmiu" and v_cnt > 16) or is_geo_field(field_name):
+        if (kind in "fcmiu" and v_cnt > 2) or is_geo_field(field_name):
             return "quantitative"
         if kind in "M" or (kind in "bOSUV" and is_temporal_field(str(example_value))):
             return 'temporal'
-        if kind in "bOSUV" or v_cnt <= 2:
-            return "nominal"
-        return "ordinal"
+        if kind in "iu":
+            return "ordinal"
+        return "nominal"
 
     def _infer_analytic(self, s: pd.Series, field_name: str):
         kind = s.dtype.kind

--- a/pygwalker/data_parsers/polars_parser.py
+++ b/pygwalker/data_parsers/polars_parser.py
@@ -49,13 +49,13 @@ class PolarsDataFrameDataParser(BaseDataFrameDataParser[pl.DataFrame]):
         example_value = s[0]
         kind = s.dtype
 
-        if (kind in pl.NUMERIC_DTYPES and v_cnt > 16) or is_geo_field(field_name):
+        if (kind in pl.NUMERIC_DTYPES and v_cnt > 2) or is_geo_field(field_name):
             return "quantitative"
         if kind in pl.TEMPORAL_DTYPES or is_temporal_field(str(example_value)):
             return "temporal"
-        if kind in [pl.Boolean, pl.Object, pl.Utf8, pl.Categorical, pl.Struct, pl.List] or v_cnt <= 2:
-            return "nominal"
-        return "ordinal"
+        if kind in [pl.Int8, pl.Int166, pl.Int32, pl.Int64, pl.UInt8, pl.UInt16, pl.UInt32, pl.UInt64]:
+            return "ordinal"
+        return "nominal"
 
     def _infer_analytic(self, s: pl.Series, field_name: str):
         kind = s.dtype

--- a/tests/test_data_parsers.py
+++ b/tests/test_data_parsers.py
@@ -15,7 +15,7 @@ sql = "SELECT COUNT(1) total FROM pygwalker_mid_table"
 sql_result = [{"total": 5}]
 raw_fields_result = [
     {'fid': 'GW_170Q6OGL68', 'name': 'name', 'semanticType': 'nominal', 'analyticType': 'dimension'},
-    {'fid': 'GW_7NL4CV2YF5C', 'name': 'count', 'semanticType': 'ordinal', 'analyticType': 'dimension'},
+    {'fid': 'GW_7NL4CV2YF5C', 'name': 'count', 'semanticType': 'quantitative', 'analyticType': 'dimension'},
     {'fid': 'GW_134F5I1A28', 'name': 'date', 'semanticType': 'temporal', 'analyticType': 'dimension'}
 ]
 to_records_result = [{'GW_170Q6OGL68': 'padnas', 'GW_7NL4CV2YF5C': 3, 'GW_134F5I1A28': '2022-01-01'}]


### PR DESCRIPTION
For now, value error (month > 12, for example), can lead to a thrown error for users.