### PR TITLE
chore: bump to v0.3.9

### DIFF
--- a/pygwalker/__init__.py
+++ b/pygwalker/__init__.py
@@ -8,7 +8,7 @@ import logging
 from pygwalker.utils.randoms import rand_str as __rand_str
 from pygwalker_utils.config import get_config as __get_config
 
-__version__ = "0.3.8"
+__version__ = "0.3.9"
 __hash__ = __rand_str()
 
 from pygwalker.api.walker import walk

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "ipywidgets",
     "pydantic",
     "psutil",
-    "duckdb",
+    "duckdb<=0.8.1",
     "pyarrow",
     "sqlglot>=18.8.0",
     "requests",


### PR DESCRIPTION
temporarily limit duckdb version to fix datetime bug, after it, dsl-parser will be updated to adapt to the new version of duckdb.

