### PR TITLE
feat: add communication on gradio(pre-demo)

### DIFF
--- a/app/src/index.tsx
+++ b/app/src/index.tsx
@@ -12,7 +12,7 @@ import { IAppProps } from './interfaces';
 import { loadDataSource, postDataService, finishDataService, getDatasFromKernelBySql, getDatasFromKernelByPayload } from './dataSource';
 
 import commonStore from "./store/common";
-import { initJupyterCommunication, initStreamlitCommunication } from "./utils/communication";
+import { initJupyterCommunication, initHttpCommunication } from "./utils/communication";
 import communicationStore from "./store/communication"
 import { setConfig, checkUploadPrivacy } from './utils/userConfig';
 import CodeExportModal from './components/codeExportModal';
@@ -201,8 +201,8 @@ const initOnJupyter = async(props: IAppProps) => {
     hidePreview(props.id);
 }
 
-const initOnStreamlit = async(props: IAppProps) => {
-    const comm = initStreamlitCommunication(props.id, props.streamlitBaseUrl);
+const initOnHttpCommunication = async(props: IAppProps) => {
+    const comm = initHttpCommunication(props.id, props.communicationUrl);
     communicationStore.setComm(comm);
     if (props.gwMode === "explore" && props.needLoadLastSpec) {
         const visSpecResp = await comm.sendMsg("get_latest_vis_spec", {});
@@ -223,7 +223,10 @@ function GWalker(props: IAppProps, id: string) {
             preRender = initOnJupyter;
             break;
         case "streamlit":
-            preRender = initOnStreamlit;
+            preRender = initOnHttpCommunication;
+            break;
+        case "gradio":
+            preRender = initOnHttpCommunication;
             break;
         default:
             preRender = defaultInit;

--- a/app/src/interfaces/index.ts
+++ b/app/src/interfaces/index.ts
@@ -15,7 +15,7 @@ export interface IAppProps extends IGWProps {
     useKernelCalc: boolean;
     useSaveTool: boolean;
     parseDslType: "server" | "client";
-    streamlitBaseUrl: string;
+    communicationUrl: string;
     gwMode: "explore" | "renderer";
     needLoadLastSpec: boolean;
     // temporary solution of saving token

--- a/app/src/utils/communication.tsx
+++ b/app/src/utils/communication.tsx
@@ -168,14 +168,14 @@ const initJupyterCommunication = (gid: string) => {
     }
 }
 
-const initStreamlitCommunication = (gid: string, baseUrl: string) => {
+const initHttpCommunication = (gid: string, baseUrl: string) => {
     // temporary solution in streamlit could
     const domain = window.parent.document.location.host.split(".").slice(-2).join('.');
     let url = "";
     if (domain === "streamlit.app") {
         url = `/~/+/_stcore/_pygwalker/comm/${gid}`
     } else {
-        url = baseUrl ? `/${baseUrl}/_stcore/_pygwalker/comm/${gid}` : `/_stcore/_pygwalker/comm/${gid}`
+        url = `/${baseUrl}/${gid}`
     }
 
     const sendMsg = async(action: string, data: any, timeout: number = 30_000) => {
@@ -216,4 +216,4 @@ const initStreamlitCommunication = (gid: string, baseUrl: string) => {
 }
 
 export type { ICommunication };
-export { initJupyterCommunication, initStreamlitCommunication };
+export { initJupyterCommunication, initHttpCommunication };

--- a/pygwalker/__init__.py
+++ b/pygwalker/__init__.py
@@ -8,7 +8,7 @@ import logging
 from pygwalker.utils.randoms import rand_str as __rand_str
 from pygwalker.services.global_var import GlobalVarManager
 
-__version__ = "0.3.10a1"
+__version__ = "0.3.10a2"
 __hash__ = __rand_str()
 
 from pygwalker.api.walker import walk

--- a/pygwalker/api/gradio.py
+++ b/pygwalker/api/gradio.py
@@ -1,0 +1,61 @@
+from typing import Union, Dict, Optional
+from typing_extensions import Literal
+
+from .pygwalker import PygWalker
+from pygwalker.communications.gradio_comm import BASE_URL_PATH, PYGWALKER_ROUTE
+from pygwalker.data_parsers.base import FieldSpec
+from pygwalker.data_parsers.database_parser import Connector
+from pygwalker._typing import DataFrame
+
+
+# pylint: disable=protected-access
+def get_html_on_gradio(
+    dataset: Union[DataFrame, Connector],
+    gid: Union[int, str] = None,
+    *,
+    fieldSpecs: Optional[Dict[str, FieldSpec]] = None,
+    themeKey: Literal['vega', 'g2'] = 'g2',
+    dark: Literal['media', 'light', 'dark'] = 'media',
+    spec: str = "",
+    debug: bool = False,
+    use_kernel_calc: bool = True,
+    **kwargs
+) -> str:
+    """Get pygwalker html render to gradio
+
+    Args:
+        - dataset (pl.DataFrame | pd.DataFrame | Connector, optional): dataframe.
+        - gid (Union[int, str], optional): GraphicWalker container div's id ('gwalker-{gid}')
+
+    Kargs:
+        - env: (Literal['Jupyter' | 'Streamlit'], optional): The enviroment using pygwalker. Default as 'Jupyter'
+        - fieldSpecs (Dict[str, FieldSpec], optional): Specifications of some fields. They'll been automatically inferred from `df` if some fields are not specified.
+        - themeKey ('vega' | 'g2'): theme type.
+        - dark (Literal['media' | 'light' | 'dark']): 'media': auto detect OS theme.
+        - spec (str): chart config data. config id, json, remote file url
+        - debug (bool): Whether to use debug mode, Default to False.
+        - use_kernel_calc(bool): Whether to use kernel compute for datas, Default to True.
+    """
+    walker = PygWalker(
+        gid=gid,
+        dataset=dataset,
+        field_specs=fieldSpecs if fieldSpecs is not None else {},
+        spec=spec,
+        source_invoke_code="",
+        hidedata_source_config=True,
+        theme_key=themeKey,
+        dark=dark,
+        show_cloud_tool=False,
+        use_preview=False,
+        store_chart_data=False,
+        use_kernel_calc=isinstance(dataset, Connector) or use_kernel_calc,
+        use_save_tool=debug,
+        **kwargs
+    )
+
+    props = walker._get_props("gradio")
+    props["communicationUrl"] = BASE_URL_PATH
+    walker.init_gradio_comm()
+
+    html = walker._get_render_iframe(props, True)
+    return html

--- a/pygwalker/api/pygwalker.py
+++ b/pygwalker/api/pygwalker.py
@@ -121,6 +121,15 @@ class PygWalker:
         comm = StreamlitCommunication(str(self.gid))
         self._init_callback(comm)
 
+    def init_gradio_comm(self):
+        """
+        Initialize the communication of gradio.
+        """
+        from pygwalker.communications.gradio_comm import GradioCommunication
+
+        comm = GradioCommunication(str(self.gid))
+        self._init_callback(comm)
+
     def get_html_on_streamlit_v2(
         self,
         *,
@@ -140,7 +149,7 @@ class PygWalker:
         else:
             props = self._get_props("streamlit")
 
-        props["streamlitBaseUrl"] = BASE_URL_PATH
+        props["communicationUrl"] = BASE_URL_PATH
         props["gwMode"] = mode
         if vis_spec is not None:
             props["visSpec"] = vis_spec

--- a/pygwalker/communications/gradio_comm.py
+++ b/pygwalker/communications/gradio_comm.py
@@ -1,0 +1,44 @@
+import json
+
+from starlette.routing import Route
+from starlette.responses import JSONResponse, Response
+from starlette.requests import Request
+
+from pygwalker.utils.encode import DataFrameEncoder
+from .base import BaseCommunication
+
+gradio_comm_map = {}
+
+BASE_URL_PATH = "/_pygwalker/comm/".strip("/")
+
+
+async def _pygwalker_router(req: Request) -> Response:
+    gid = req.path_params["gid"]
+    comm_obj = gradio_comm_map.get(gid, None)
+    if comm_obj is None:
+        return JSONResponse({"success": False, "message": f"Unknown gid: {gid}"})
+    json_data = await req.json()
+    # pylint: disable=protected-access
+    result = json.dumps(
+        comm_obj._receive_msg(json_data["action"], json_data["data"]),
+        cls=DataFrameEncoder
+    )
+    return JSONResponse(json.loads(result))
+
+
+class GradioCommunication(BaseCommunication):
+    """
+    Hacker streamlit communication class.
+    only support receive message.
+    """
+    def __init__(self, gid: str) -> None:
+        super().__init__()
+        gradio_comm_map[gid] = self
+        self.gid = gid
+
+
+PYGWALKER_ROUTE = Route(
+    "/_pygwalker/comm/{gid}",
+    _pygwalker_router,
+    methods=["POST"]
+)

--- a/pygwalker/communications/streamlit_comm.py
+++ b/pygwalker/communications/streamlit_comm.py
@@ -12,9 +12,10 @@ from .base import BaseCommunication
 
 streamlit_comm_map = {}
 
-BASE_URL_PATH = config.get_option("server.baseUrlPath").strip("/")
+_STREAMLIT_PREFIX_URL = config.get_option("server.baseUrlPath").strip("/")
+BASE_URL_PATH = (_STREAMLIT_PREFIX_URL + "/_stcore/_pygwalker/comm/").strip("/")
 PYGWALKER_API_PATH = make_url_path_regex(
-    BASE_URL_PATH,
+    _STREAMLIT_PREFIX_URL,
     r"/_stcore/_pygwalker/comm/(.+)"
 )
 


### PR DESCRIPTION
support pygwalker use duckdb in gradio.

Just a pre-release demo version, Communication won't work when gradio is reloaded (to be fixed).


```python
import gradio as gr
import pandas as pd

from pygwalker.api.gradio import PYGWALKER_ROUTE, get_html_on_gradio

with gr.Blocks() as demo:
    df = pd.read_csv("/Users/douding/Desktop/datas/hour.csv")
    pyg_html = get_html_on_gradio(df, spec="gradio.json", debug=True)
    gr.HTML(pyg_html)


app = demo.launch(app_kwargs={
    "routes": [PYGWALKER_ROUTE]
})
```