### PR TITLE
fix: streamlit api - get_streamlit_html

### DIFF
--- a/pygwalker/__init__.py
+++ b/pygwalker/__init__.py
@@ -8,7 +8,7 @@ import logging
 from pygwalker.utils.randoms import rand_str as __rand_str
 from pygwalker.services.global_var import GlobalVarManager
 
-__version__ = "0.3.10"
+__version__ = "0.3.11"
 __hash__ = __rand_str()
 
 from pygwalker.api.walker import walk

--- a/pygwalker/api/streamlit.py
+++ b/pygwalker/api/streamlit.py
@@ -241,10 +241,9 @@ def get_streamlit_html(
     renderer = StreamlitRenderer(
         gid=gid,
         dataset=dataset,
-        field_specs=fieldSpecs,
+        fieldSpecs=fieldSpecs,
         spec=spec,
-        source_invoke_code="",
-        theme_key=themeKey,
+        themeKey=themeKey,
         dark=dark,
         debug=debug,
         use_kernel_calc=use_kernel_calc,


### PR DESCRIPTION
fix api: `get_streamlit_html`

expect:

run code,

```python
from pygwalker.api.streamlit import get_streamlit_html
import pandas as pd

df = pd.Dataframe()
html = get_streamlit_html(df)
```

return html string.
