### PR TITLE
feat: add export dataframe tool

### DIFF
--- a/app/src/dataSource/index.ts
+++ b/app/src/dataSource/index.ts
@@ -86,11 +86,11 @@ export function getDatasFromKernelBySql(fieldMetas: any) {
             JSON.stringify(fieldMetas)
         );
         const result = await communicationStore.comm?.sendMsg("get_datas", {"sql": sql});
-        return result["data"]["datas"] as IRow[];
+        return result && result["data"]["datas"] as IRow[];
     }
 }
 
 export async function getDatasFromKernelByPayload(payload: IDataQueryPayload) {
     const result = await communicationStore.comm?.sendMsg("get_datas_by_payload", {payload});
-    return result["data"]["datas"] as IRow[];
+    return result && result["data"]["datas"] as IRow[];
 }

--- a/app/src/index.tsx
+++ b/app/src/index.tsx
@@ -21,6 +21,7 @@ import InitModal from './components/initModal';
 import { getSaveTool, hidePreview } from './tools/saveTool';
 import { getExportTool } from './tools/exportTool';
 import { getShareTool } from './tools/shareTool';
+import { getExportDataframeTool } from './tools/exportDataframe';
 import { formatExportedChartDatas } from "./utils/save";
 import Notification from "./notify"
 import initDslParser from "@kanaries-temp/gw-dsl-parser";
@@ -101,15 +102,19 @@ const App: React.FC<IAppProps> = observer((props) => {
     }, []);
 
     const exportTool = getExportTool(setExportOpen);
-    const saveTool = getSaveTool(props, gwRef, storeRef);
-    const uploadTool = getShareTool(setShareModalOpen);
 
     const tools = [exportTool];
     if ((props.env === "jupyter_widgets" || props.env === "streamlit" || props.env === "gradio") && props.useSaveTool) {
+        const saveTool = getSaveTool(props, gwRef, storeRef);
         tools.push(saveTool);
     }
     if (checkUploadPrivacy() && commonStore.showCloudTool) {
+        const uploadTool = getShareTool(setShareModalOpen);
         tools.push(uploadTool);
+    }
+    if (props.isExportDataFrame) {
+        const exportDataFrameTool = getExportDataframeTool(props, storeRef);
+        tools.push(exportDataFrameTool);
     }
 
     const toolbarConfig = {
@@ -189,9 +194,7 @@ const initOnJupyter = async(props: IAppProps) => {
     if (props.needLoadDatas) {
         comm.sendMsgAsync("request_data", {}, null);
     }
-    if (props.useKernelCalc) {
-        await initDslParser();
-    }
+    await initDslParser();
     hidePreview(props.id);
 }
 
@@ -202,9 +205,7 @@ const initOnHttpCommunication = async(props: IAppProps) => {
         const visSpecResp = await comm.sendMsg("get_latest_vis_spec", {});
         props.visSpec = visSpecResp["data"]["visSpec"];
     }
-    if (props.useKernelCalc) {
-        await initDslParser();
-    }
+    await initDslParser();
 }
 
 const defaultInit = async(props: IAppProps) => {}

--- a/app/src/interfaces/index.ts
+++ b/app/src/interfaces/index.ts
@@ -28,6 +28,7 @@ export interface IAppProps {
     needLoadLastSpec: boolean;
     extraConfig?: any;
     fieldMetas: any;
+    isExportDataFrame: boolean;
 }
 
 export interface IDataSourceProps {

--- a/app/src/notify/index.tsx
+++ b/app/src/notify/index.tsx
@@ -35,7 +35,7 @@ const Notification: React.FC = observer(() => {
                             leaveFrom="opacity-100"
                             leaveTo="opacity-0"
                         >
-                            <div className="pointer-events-auto w-full max-w-sm overflow-hidden rounded-lg bg-zinc-700 shadow-lg ring-1 ring-black ring-opacity-5">
+                            <div className="pointer-events-auto w-full max-w-md overflow-hidden rounded-lg bg-zinc-700 shadow-lg ring-1 ring-black ring-opacity-5">
                                 <div className="p-4">
                                     <div className="flex items-start">
                                         <div className="flex-shrink-0">

--- a/app/src/tools/exportDataframe.tsx
+++ b/app/src/tools/exportDataframe.tsx
@@ -1,0 +1,73 @@
+import React, { useState } from 'react';
+import communicationStore from "../store/communication"
+import commonStore from '../store/common';
+
+import { DocumentArrowDownIcon } from '@heroicons/react/24/outline';
+import LoadingIcon from '../components/loadingIcon';
+
+import type { IAppProps } from '../interfaces';
+import { parser_dsl_with_meta } from "@kanaries-temp/gw-dsl-parser";
+import type { ToolbarButtonItem } from "@kanaries/graphic-walker/dist/components/toolbar/toolbar-button"
+import type { VizSpecStore } from '@kanaries/graphic-walker/dist/store/visualSpecStore'
+
+export function getExportDataframeTool(
+    props: IAppProps,
+    storeRef: React.MutableRefObject<VizSpecStore | null>
+) : ToolbarButtonItem {
+    const [exporting, setExporting] = useState(false);
+
+    const exportSuccess = () => {
+        commonStore.setNotification({
+            type: "success",
+            title: "Tips",
+            message: <>
+            <p className='py-1'>export success, created new dataframe: </p>
+            <p className='font-semibold py-1'>`walker.last_exported_dataframe`</p>
+            <p className='py-1'>if you forgot set variable walker, you can use</p>
+            <p className='font-semibold py-1'>`pyg.GlobalVarManager.last_exported_dataframe`</p>
+            <p className='py-1'>to get current exported dataframe</p>
+            </>
+        }, 20_000);
+
+        setTimeout(() => {
+            setExporting(false);
+        }, 500);
+    }
+
+    const onClick = async () => {
+        if (exporting) return;
+        setExporting(true);
+        try {
+            if (props.parseDslType === "server") {
+                await communicationStore.comm?.sendMsg("export_dataframe_by_payload", {
+                    payload: {
+                        workflow: storeRef.current?.workflow,
+                    },
+                    encodings: storeRef.current?.currentVis.encodings,
+                });
+            } else {
+                const sql = parser_dsl_with_meta(
+                    "pygwalker_mid_table",
+                    JSON.stringify({workflow: storeRef.current?.workflow}),
+                    JSON.stringify(props.fieldMetas)
+                );
+                await communicationStore.comm?.sendMsg("export_dataframe_by_sql", {
+                    sql: sql,
+                    encodings: storeRef.current?.currentVis.encodings,
+                });
+            }
+            exportSuccess();
+        } catch (_) {
+            setExporting(false);
+        }
+    }
+
+    return {
+        key: "export_dataframe",
+        label: "export_dataframe",
+        icon: (iconProps?: any) => {
+            return exporting ? <LoadingIcon width={36} height={36} /> : <DocumentArrowDownIcon {...iconProps} />
+        },
+        onClick: onClick,
+    }
+}

--- a/pygwalker/api/gradio.py
+++ b/pygwalker/api/gradio.py
@@ -50,6 +50,7 @@ def get_html_on_gradio(
         store_chart_data=False,
         use_kernel_calc=isinstance(dataset, Connector) or use_kernel_calc,
         use_save_tool=debug,
+        is_export_dataframe=False,
         **kwargs
     )
 

--- a/pygwalker/api/html.py
+++ b/pygwalker/api/html.py
@@ -58,6 +58,7 @@ def to_html(
         use_kernel_calc=False,
         use_save_tool=False,
         gw_mode="explore",
+        is_export_dataframe=False,
         **kwargs
     )
 

--- a/pygwalker/api/kanaries_cloud.py
+++ b/pygwalker/api/kanaries_cloud.py
@@ -45,6 +45,7 @@ def create_cloud_walker(
         use_kernel_calc=False,
         use_save_tool=False,
         gw_mode="explore",
+        is_export_dataframe=False,
     )
 
     create_cloud_graphic_walker(

--- a/pygwalker/api/streamlit.py
+++ b/pygwalker/api/streamlit.py
@@ -86,6 +86,7 @@ class StreamlitRenderer:
             store_chart_data=False,
             use_kernel_calc=isinstance(dataset, Connector) or use_kernel_calc,
             use_save_tool=debug,
+            is_export_dataframe=False,
             **kwargs
         )
         self.walker.init_streamlit_comm()

--- a/pygwalker/api/walker.py
+++ b/pygwalker/api/walker.py
@@ -68,6 +68,7 @@ def walk(
         use_kernel_calc=isinstance(dataset, Connector) or use_kernel_calc,
         use_save_tool=True,
         gw_mode="explore",
+        is_export_dataframe=True,
         **kwargs
     )
 

--- a/pygwalker/services/global_var.py
+++ b/pygwalker/services/global_var.py
@@ -1,5 +1,6 @@
 import os
 
+from pandas import DataFrame
 from typing_extensions import Literal
 
 from .config import get_config
@@ -13,6 +14,7 @@ class GlobalVarManager:
     kanaries_api_key = get_config("kanaries_token") or os.getenv("KANARIES_API_KEY", "")
     kanaries_api_host = "https://api.kanaries.net"
     kanaries_main_host = "https://kanaries.net"
+    last_exported_dataframe = None
 
     @classmethod
     def get_global_gid(cls) -> int:
@@ -43,3 +45,7 @@ class GlobalVarManager:
     @classmethod
     def set_privacy(cls, privacy: Literal['offline', 'update-only', 'events']):
         cls.privacy = privacy
+
+    @classmethod
+    def set_last_exported_dataframe(cls, df: DataFrame):
+        cls.last_exported_dataframe = df

--- a/pygwalker/services/spec.py
+++ b/pygwalker/services/spec.py
@@ -108,6 +108,13 @@ def _config_adapter(config: str) -> str:
     return json.dumps(config_obj)
 
 
+def get_fid_fname_map_from_encodings(encodings: Dict[str, Any]) -> Dict[str, str]:
+    return {
+        field["fid"]: field["name"]
+        for field in encodings["dimensions"] + encodings["measures"]
+    }
+
+
 def fill_new_fields(config: str, all_fields: List[Dict[str, str]]) -> str:
     """when df schema changed, fill new fields to every chart config"""
     config_obj = json.loads(config)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,8 @@ dependencies = [
     "sqlalchemy",
     "gw_dsl_parser==0.1.7a11",
     "appdirs",
-    "segment-analytics-python==2.2.3"
+    "segment-analytics-python==2.2.3",
+    "pandas"
 ]
 [project.urls]
 homepage = "https://github.com/Kanaries/pygwalker"


### PR DESCRIPTION
Users can export the current chart data into a dataframe of pandas in jupyter notebook. This feature also prepares for the export various calculation measures provided by graphch-walker in the future.

