### PR TITLE
feat: raise error when use incorrect view sql

### DIFF
--- a/pygwalker/errors.py
+++ b/pygwalker/errors.py
@@ -36,3 +36,8 @@ class CloudFunctionError(BaseError):
 class CsvFileTooLargeError(BaseError):
     """Raised when the csv file is too large."""
     pass
+
+
+class ViewSqlSameColumnError(BaseError):
+    """Raised when the view sql is invalid."""
+    pass


### PR DESCRIPTION
pygwalker won't work when users use connector and use incorrect `view_sql`, so pygwalker will check view_sql in advance and throw an exception in advance if it is incorrect.

