### PR TITLE
feat: remove encoding field name

### DIFF
--- a/pygwalker/__init__.py
+++ b/pygwalker/__init__.py
@@ -10,7 +10,7 @@ from pygwalker.utils.execute_env_check import check_kaggle as __check_kaggle
 from pygwalker.services.global_var import GlobalVarManager
 from pygwalker.services.kaggle import show_tips_user_kaggle as __show_tips_user_kaggle
 
-__version__ = "0.3.17a4"
+__version__ = "0.3.17a5"
 __hash__ = __rand_str()
 
 from pygwalker.api.walker import walk

--- a/pygwalker/data_parsers/base.py
+++ b/pygwalker/data_parsers/base.py
@@ -114,7 +114,7 @@ class BaseDataFrameDataParser(Generic[DataFrame], BaseDataParser):
             (IMutField, Dict)
         """
         s = self._example_df[col]
-        orig_fname = self._decode_fname(s)
+        orig_fname = col
         field_spec = field_specs.get(orig_fname, default_field_spec)
         semantic_type = self._infer_semantic(s, orig_fname) if field_spec.semanticType == '?' else field_spec.semanticType
         analytic_type = self._infer_analytic(s, orig_fname) if field_spec.analyticType == '?' else field_spec.analyticType

--- a/pygwalker/data_parsers/modin_parser.py
+++ b/pygwalker/data_parsers/modin_parser.py
@@ -10,7 +10,7 @@ from .base import (
     is_temporal_field,
     is_geo_field
 )
-from pygwalker.services.fname_encodings import fname_decode, fname_encode, rename_columns
+from pygwalker.services.fname_encodings import rename_columns
 
 
 class ModinPandasDataFrameDataParser(BaseDataFrameDataParser[mpd.DataFrame]):
@@ -31,7 +31,7 @@ class ModinPandasDataFrameDataParser(BaseDataFrameDataParser[mpd.DataFrame]):
 
     def _rename_dataframe(self, df: mpd.DataFrame) -> mpd.DataFrame:
         df = df.reset_index(drop=True)
-        df.columns = [fname_encode(col) for col in rename_columns(list(df.columns))]
+        df.columns = rename_columns(list(df.columns))
         return df
 
     def _preprocess_dataframe(self, df: mpd.DataFrame) -> mpd.DataFrame:
@@ -59,11 +59,6 @@ class ModinPandasDataFrameDataParser(BaseDataFrameDataParser[mpd.DataFrame]):
             return "measure"
 
         return "dimension"
-
-    def _decode_fname(self, s: mpd.Series):
-        fname = fname_decode(s.name).rsplit('_', 1)[0]
-        fname = json.dumps(fname, ensure_ascii=False)[1:-1]
-        return fname
 
     @property
     def dataset_tpye(self) -> str:

--- a/pygwalker/data_parsers/pandas_parser.py
+++ b/pygwalker/data_parsers/pandas_parser.py
@@ -9,7 +9,7 @@ from .base import (
     is_temporal_field,
     is_geo_field
 )
-from pygwalker.services.fname_encodings import fname_decode, fname_encode, rename_columns
+from pygwalker.services.fname_encodings import rename_columns
 
 
 class PandasDataFrameDataParser(BaseDataFrameDataParser[pd.DataFrame]):
@@ -27,7 +27,7 @@ class PandasDataFrameDataParser(BaseDataFrameDataParser[pd.DataFrame]):
 
     def _rename_dataframe(self, df: pd.DataFrame) -> pd.DataFrame:
         df = df.reset_index(drop=True)
-        df.columns = [fname_encode(col) for col in rename_columns(list(df.columns))]
+        df.columns = rename_columns(list(df.columns))
         return df
 
     def _preprocess_dataframe(self, df: pd.DataFrame) -> pd.DataFrame:
@@ -54,11 +54,6 @@ class PandasDataFrameDataParser(BaseDataFrameDataParser[pd.DataFrame]):
             return "measure"
 
         return "dimension"
-
-    def _decode_fname(self, s: pd.Series):
-        fname = fname_decode(s.name).rsplit('_', 1)[0]
-        fname = json.dumps(fname, ensure_ascii=False)[1:-1]
-        return fname
 
     @property
     def dataset_tpye(self) -> str:

--- a/pygwalker/data_parsers/polars_parser.py
+++ b/pygwalker/data_parsers/polars_parser.py
@@ -9,7 +9,7 @@ from .base import (
     is_temporal_field,
     is_geo_field
 )
-from pygwalker.services.fname_encodings import fname_decode, fname_encode, rename_columns
+from pygwalker.services.fname_encodings import rename_columns
 
 
 class PolarsDataFrameDataParser(BaseDataFrameDataParser[pl.DataFrame]):
@@ -27,7 +27,7 @@ class PolarsDataFrameDataParser(BaseDataFrameDataParser[pl.DataFrame]):
 
     def _rename_dataframe(self, df: pl.DataFrame) -> pl.DataFrame:
         df = df.rename({
-            old_col: fname_encode(new_col)
+            old_col: new_col
             for old_col, new_col in zip(df.columns, rename_columns(df.columns))
         })
         return df
@@ -60,11 +60,6 @@ class PolarsDataFrameDataParser(BaseDataFrameDataParser[pl.DataFrame]):
             return "measure"
 
         return "dimension"
-
-    def _decode_fname(self, s: pl.Series):
-        fname = fname_decode(s.name).rsplit('_', 1)[0]
-        fname = json.dumps(fname, ensure_ascii=False)[1:-1]
-        return fname
 
     @property
     def dataset_tpye(self) -> str:

--- a/pygwalker/data_parsers/spark_parser.py
+++ b/pygwalker/data_parsers/spark_parser.py
@@ -8,7 +8,7 @@ import sqlglot
 
 from .base import BaseDataParser, get_data_meta_type
 from .pandas_parser import PandasDataFrameDataParser
-from pygwalker.services.fname_encodings import fname_encode, rename_columns
+from pygwalker.services.fname_encodings import rename_columns
 from pygwalker.data_parsers.base import FieldSpec
 from pygwalker.utils.payload_to_sql import get_sql_from_payload
 
@@ -69,7 +69,7 @@ class SparkDataFrameDataParser(BaseDataParser):
         return content
 
     def _rename_dataframe(self, df: DataFrame) -> DataFrame:
-        new_columns = [fname_encode(col) for col in rename_columns(list(df.columns))]
+        new_columns = rename_columns(list(df.columns))
         return df.toDF(*new_columns)
 
     def _preprocess_dataframe(self, df: DataFrame) -> DataFrame:

--- a/pygwalker/services/fname_encodings.py
+++ b/pygwalker/services/fname_encodings.py
@@ -51,6 +51,9 @@ def rename_columns(columns: List[str]) -> List[str]:
     column_map = defaultdict(lambda: 0)
     renamed_columns = []
     for col in columns:
-        renamed_columns.append(f"{col}_{column_map[col]}")
+        if column_map[col] == 0:
+            renamed_columns.append(col)
+        else:
+            renamed_columns.append(f"{col}_{column_map[col]}")
         column_map[col] += 1
     return renamed_columns

--- a/tests/test_data_parsers.py
+++ b/tests/test_data_parsers.py
@@ -17,12 +17,12 @@ datas = [
 sql = "SELECT COUNT(1) total FROM pygwalker_mid_table"
 sql_result = [{"total": 5}]
 raw_fields_result = [
-    {'fid': 'GW_170Q6OGL68', 'name': 'name', 'semanticType': 'nominal', 'analyticType': 'dimension'},
-    {'fid': 'GW_7NL4CV2YF5C', 'name': 'count', 'semanticType': 'quantitative', 'analyticType': 'dimension'},
-    {'fid': 'GW_134F5I1A28', 'name': 'date', 'semanticType': 'temporal', 'analyticType': 'dimension'}
+    {'fid': 'name', 'name': 'name', 'semanticType': 'nominal', 'analyticType': 'dimension'},
+    {'fid': 'count', 'name': 'count', 'semanticType': 'quantitative', 'analyticType': 'dimension'},
+    {'fid': 'date', 'name': 'date', 'semanticType': 'temporal', 'analyticType': 'dimension'}
 ]
-to_records_result = [{'GW_170Q6OGL68': 'padnas', 'GW_7NL4CV2YF5C': 3, 'GW_134F5I1A28': '2022-01-01'}]
-to_records_no_kernrl_result = [{'GW_170Q6OGL68': 'padnas', 'GW_7NL4CV2YF5C': 3, 'GW_134F5I1A28': '2022-01-01'}]
+to_records_result = [{'name': 'padnas', 'count': 3, 'date': '2022-01-01'}]
+to_records_no_kernrl_result = [{'name': 'padnas', 'count': 3, 'date': '2022-01-01'}]
 
 
 def test_data_parser_on_padnas():


### PR DESCRIPTION
Previously, pygwalker encoded fields to be compatible with the graphic-walker config format. This is no longer necessary, so we have removed the logic for double encoding fields.

This also makes it easier for us to provide computed fields in the future.