### PR TITLE
feat: add metrics chart feature

### DIFF
--- a/pygwalker/__init__.py
+++ b/pygwalker/__init__.py
@@ -10,7 +10,7 @@ from pygwalker.utils.execute_env_check import check_kaggle as __check_kaggle
 from pygwalker.services.global_var import GlobalVarManager
 from pygwalker.services.kaggle import show_tips_user_kaggle as __show_tips_user_kaggle
 
-__version__ = "0.3.19"
+__version__ = "0.3.20a0"
 __hash__ = __rand_str()
 
 from pygwalker.api.walker import walk

--- a/pygwalker/data_parsers/base.py
+++ b/pygwalker/data_parsers/base.py
@@ -88,6 +88,12 @@ class BaseDataParser(abc.ABC):
         """get field metas"""
         raise NotImplementedError
 
+    @property
+    @abc.abstractmethod
+    def placeholder_table_name(self) -> str:
+        """get placeholder table name"""
+        raise NotImplementedError
+
 
 class BaseDataFrameDataParser(Generic[DataFrame], BaseDataParser):
     """DataFrame property getter"""
@@ -202,6 +208,10 @@ class BaseDataFrameDataParser(Generic[DataFrame], BaseDataParser):
     @property
     def dataset_tpye(self) -> str:
         return "dataframe_default"
+
+    @property
+    def placeholder_table_name(self) -> str:
+        return "pygwalker_mid_table"
 
 
 def is_temporal_field(value: Any, infer_string_to_date: bool) -> bool:

--- a/pygwalker/data_parsers/cloud_dataset_parser.py
+++ b/pygwalker/data_parsers/cloud_dataset_parser.py
@@ -88,3 +88,7 @@ class CloudDatasetParser(BaseDataParser):
     @property
     def dataset_tpye(self) -> str:
         return "cloud_dataset"
+
+    @property
+    def placeholder_table_name(self) -> str:
+        return "pygwalker_mid_table"

--- a/pygwalker/data_parsers/spark_parser.py
+++ b/pygwalker/data_parsers/spark_parser.py
@@ -95,3 +95,7 @@ class SparkDataFrameDataParser(BaseDataParser):
     @property
     def dataset_tpye(self) -> str:
         return "spark_dataframe"
+
+    @property
+    def placeholder_table_name(self) -> str:
+        return "pygwalker_mid_table"

--- a/pygwalker_tools/metrics/__init__.py
+++ b/pygwalker_tools/metrics/__init__.py
@@ -1,0 +1,3 @@
+from .api import get_metrics_datas, MetricsChart
+
+__all__ = ["get_metrics_datas", "MetricsChart"]

--- a/pygwalker_tools/metrics/api.py
+++ b/pygwalker_tools/metrics/api.py
@@ -1,0 +1,228 @@
+from typing import List, Dict, Any, Union, Optional
+from decimal import Decimal
+import json
+
+import altair as alt
+import pandas as pd
+
+from pygwalker._typing import DataFrame
+from pygwalker.data_parsers.database_parser import Connector
+from pygwalker.services.data_parsers import get_parser
+from .core import get_metrics_sql
+
+
+class _JSONEncoder(json.JSONEncoder):
+    """JSON encoder"""
+    def default(self, o):
+        if isinstance(o, Decimal):
+            if o.is_nan():
+                return None
+            return float(o)
+
+        return json.JSONEncoder.default(self, o)
+
+
+def get_metrics_datas(
+    dataset: Union[DataFrame, Connector],
+    metrics_name: str,
+    field_map: Dict[str, str],
+    params: Optional[Dict[str, Any]] = None,
+    timezone_offset_seconds: Optional[int] = None,
+) -> List[Dict[str, Any]]:
+    """
+    Example: get 1 day retention datas
+    ```python
+    from pygwalker_tools.metrics import get_metrics_datas
+    datas = get_metrics_datas(
+        dataset=dataset,
+        metrics_name="retention",
+        field_map={
+            "date": "your_date_field",
+            "user_id": "your_user_id_field",
+            "user_signup_date": "your_user_signup_date_field"
+        },
+        params={
+            "time_unit": "day",
+            "time_size": 1
+    )
+    ```
+    Available metrics:
+    - pv: Page Views
+        - fields: ['date']
+        - dimensions: ['date']
+        - params: []
+    - uv: User Views
+        - fields: ['date', 'user_id']
+        - dimensions: ['date']
+        - params: []
+    - mau: Monthly Active Users
+        - fields: ['date', 'user_id']
+        - dimensions: ['date']
+        - params: []
+    - retention: Retention
+        - fields: ['date', 'user_id', 'user_signup_date']
+        - dimensions: ['date']
+        - params: ['time_unit', 'time_size']
+    - new_user_count: New User Count
+        - fields: ['date', 'user_id', 'user_signup_date']
+        - dimensions: ['date']
+        - params: []
+    """
+    if isinstance(dataset, str):
+        raise TypeError("Unsupported cloud dataset type")
+
+    if params is None:
+        params = {}
+
+    parser = get_parser(dataset)
+    sql = get_metrics_sql(
+        name=metrics_name,
+        field_map=field_map,
+        params=params,
+        origin_table_name=parser.placeholder_table_name
+    )
+
+    if isinstance(dataset, Connector):
+        return parser._get_datas_by_sql(sql)
+    else:
+        return parser.get_datas_by_sql(sql, timezone_offset_seconds)
+
+
+class MetricsChart:
+    """
+    Example: get 7 day retention chart
+    ```python
+    from pygwalker_tools.metrics import MetricsChart
+    MetricsChart(
+        dataset,
+        {"date": "your_date_field", "user_id": "your_user_id_field", "user_signup_date": "your_user_signup_date_field"},
+        params={"time_unit": "day", "time_size": 7}
+    ).retention()
+    ```
+    Available metrics:
+    - pv: Page Views
+        - fields: ['date']
+        - dimensions: ['date']
+        - params: []
+    - uv: User Views
+        - fields: ['date', 'user_id']
+        - dimensions: ['date']
+        - params: []
+    - mau: Monthly Active Users
+        - fields: ['date', 'user_id']
+        - dimensions: ['date']
+        - params: []
+    - retention: Retention
+        - fields: ['date', 'user_id', 'user_signup_date']
+        - dimensions: ['date']
+        - params: ['time_unit', 'time_size']
+    - new_user_count: New User Count
+        - fields: ['date', 'user_id', 'user_signup_date']
+        - dimensions: ['date']
+        - params: []
+    - cohort_matrix: Cohort Matrix
+        - fields: ['date', 'user_id', 'user_signup_date']
+        - dimensions: ['date', 'time_size']
+        - params: []
+    """
+    def __init__(
+        self,
+        dataset: Union[DataFrame, Connector],
+        field_map: Dict[str, str],
+        params: Optional[Dict[str, Any]] = None,
+        timezone_offset_seconds: Optional[int] = None,
+        reverse_axis: bool = False
+    ):
+        self.dataset = dataset
+        self.field_map = field_map
+        self.params = params
+        self.timezone_offset_seconds = timezone_offset_seconds
+        self.reverse_axis = reverse_axis
+
+    def _get_datas(self, metrics_name: str, params: Optional[Dict[str, Any]] = None) -> pd.DataFrame:
+        datas = get_metrics_datas(
+            dataset=self.dataset,
+            metrics_name=metrics_name,
+            field_map=self.field_map,
+            params=params or self.params,
+            timezone_offset_seconds=self.timezone_offset_seconds
+        )
+        return pd.DataFrame(json.loads(json.dumps(datas, cls=_JSONEncoder)))
+
+    def _format_encode(self, encode_params: Dict[str, Any]) -> Dict[str, Any]:
+        if self.reverse_axis:
+            encode_params["x"], encode_params["y"] = encode_params["y"], encode_params["x"]
+        return encode_params
+
+    def pv(self) -> alt.Chart:
+        datas = self._get_datas("pv")
+        encode_params = {
+            "x": "date",
+            "y": "pv",
+            "tooltip": ["date", "pv"]
+        }
+        return alt.Chart(datas).mark_line().encode(
+            **self._format_encode(encode_params)
+        )
+
+    def uv(self) -> alt.Chart:
+        datas = self._get_datas("uv")
+        encode_params = {
+            "x": "date",
+            "y": "uv",
+            "tooltip": ["date", "uv"]
+        }
+        return alt.Chart(datas).mark_line().encode(
+            **self._format_encode(encode_params)
+        )
+
+    def mau(self) -> alt.Chart:
+        datas = self._get_datas("mau")
+        encode_params = {
+            "x": "date",
+            "y": "mau",
+            "tooltip": ["date", "mau"]
+        }
+        return alt.Chart(datas).mark_line().encode(
+            **self._format_encode(encode_params)
+        )
+
+    def retention(self) -> alt.Chart:
+        datas = self._get_datas("retention")
+        encode_params = {
+            "x": "date",
+            "y": "retention",
+            "tooltip": ["date", "retention"]
+        }
+        return alt.Chart(datas).mark_line().encode(
+            **self._format_encode(encode_params)
+        )
+
+    def new_user_count(self) -> alt.Chart:
+        datas = self._get_datas("new_user_count")
+        encode_params = {
+            "x": "date",
+            "y": "new_user_count",
+            "tooltip": ["date", "new_user_count"],
+        }
+        return alt.Chart(datas).mark_bar().encode(
+            **self._format_encode(encode_params)
+        )
+
+    def cohort_matrix(self) -> alt.Chart:
+        all_df = []
+        for i in range(1, 31):
+            df = self._get_datas("retention", {"time_unit": "day", "time_size": i})
+            df["time_size"] = i
+            all_df.append(df)
+
+        datas = pd.concat(all_df)
+        encode_params = {
+            "x": "time_size:O",
+            "y": "date:O",
+            "color": "retention",
+            "tooltip": ["date", "time_size", "retention"]
+        }
+        return alt.Chart(datas).mark_rect().encode(
+            **self._format_encode(encode_params)
+        )

--- a/pygwalker_tools/metrics/core.py
+++ b/pygwalker_tools/metrics/core.py
@@ -1,0 +1,176 @@
+from typing import Dict, Any
+
+import sqlglot.expressions as exp
+import sqlglot
+
+METRICS_DEFINITIONS = {
+    "pv": {
+        "name": "pv",
+        "description": "Page Views",
+        "fields": ["date"],
+        "dimensions": ["date"],
+        "params": [],
+        "sql": """
+            SELECT
+                strftime("date", '%Y-%m-%d') "date",
+                COUNT(1) "pv"
+            FROM
+                "___default_table___"
+            GROUP BY
+                strftime("date", '%Y-%m-%d')
+        """
+    },
+    "uv": {
+        "name": "uv",
+        "description": "User Views",
+        "fields": ["date", "user_id"],
+        "dimensions": ["date"],
+        "params": [],
+        "sql": """
+            SELECT
+                strftime("date", '%Y-%m-%d') "date",
+                COUNT(DISTINCT "user_id") "uv"
+            FROM
+                "___default_table___"
+            GROUP BY
+                strftime("date", '%Y-%m-%d')
+        """
+    },
+    "mau": {
+        "name": "mau",
+        "description": "Monthly Active Users",
+        "fields": ["date", "user_id"],
+        "dimensions": ["date"],
+        "params": [],
+        "sql": """
+            SELECT
+                strftime("date", '%Y-%m') "date",
+                COUNT(DISTINCT "user_id") "mau"
+            FROM
+                "___default_table___"
+            GROUP BY
+                strftime("date", '%Y-%m')
+        """
+    },
+    "retention": {
+        "name": "retention",
+        "description": "Retention",
+        "fields": ["date", "user_id", "user_signup_date"],
+        "dimensions": ["date"],
+        "params": ["time_unit", "time_size"],
+        "sql": """
+            SELECT
+                strftime(t0."date", '%Y-%m-%d') "date",
+                COUNT(DISTINCT t1."user_id") / COUNT(DISTINCT t0."user_id") "retention"
+            FROM (
+                SELECT
+                    DISTINCT "date"::date "date", "user_id"
+                FROM
+                    "___default_table___"
+                WHERE
+                    "date"::date = "user_signup_date"::date
+            ) t0
+            LEFT JOIN (
+                SELECT
+                    DISTINCT "date"::date "date", "user_id"
+                FROM
+                    "___default_table___"
+            ) t1
+            ON
+                t0."user_id" = t1."user_id" AND
+                t0."date" < t1."date" AND
+                datediff('{time_unit}', t0."date", t1."date") = {time_size}
+            GROUP BY
+                strftime(t0."date", '%Y-%m-%d')
+        """
+    },
+    "new_user_count": {
+        "name": "new_user_count",
+        "description": "New User Count",
+        "fields": ["date", "user_id", "user_signup_date"],
+        "dimensions": ["date"],
+        "params": [],
+        "sql": """
+            SELECT
+                strftime("___default_table___"."date", '%Y-%m-%d') "date",
+                COUNT(DISTINCT "___default_table___"."user_id") "new_user_count"
+            FROM
+                "___default_table___"
+            WHERE
+                "date"::date = "user_signup_date"::date
+            GROUP BY
+                strftime("___default_table___"."date", '%Y-%m-%d')
+        """
+    }
+}
+
+
+def get_metrics_sql(
+    *,
+    name: str,
+    field_map: Dict[str, str],
+    params: Dict[str, Any],
+    origin_table_name: str
+) -> str:
+    """get metrics sql"""
+    if name not in METRICS_DEFINITIONS:
+        raise ValueError(f"Unknown metrics name: {name}")
+    metrics_definition = METRICS_DEFINITIONS[name]
+
+    if set(metrics_definition["fields"]) != set(field_map.keys()):
+        raise ValueError(f"Fields not match: {metrics_definition['fields']}")
+
+    if set(metrics_definition["params"]) != set(params.keys()):
+        raise ValueError(f"Params not match: {metrics_definition['params']}")
+
+    timestamp_field = {"date"}
+
+    field_map_sql = ",\n".join([
+        f'"{field_map[field]}" "{field}"' if field not in timestamp_field else f'"{field_map[field]}"::timestamp "{field}"'
+        for field in metrics_definition["fields"]
+    ])
+    sub_query = f"""
+        SELECT
+            {field_map_sql}
+        FROM
+            "{origin_table_name}"
+    """
+
+    origin_sql_ast = sqlglot.parse(sub_query, read="duckdb")[0]
+    sub_query_node = exp.Subquery(
+        this=origin_sql_ast,
+        alias="___default_table___"
+    )
+
+    sql_str = metrics_definition["sql"].format(**params)
+    sql_ast = sqlglot.parse(sql_str, read="duckdb")[0]
+    for from_exp in sql_ast.find_all(exp.From, exp.Join):
+        if str(from_exp.this.this).strip('"') == "___default_table___":
+            if str(from_exp.this.alias):
+                alias_name = from_exp.this.alias
+            else:
+                alias_name = "___default_table___"
+            sub_query_node = exp.Subquery(
+                this=origin_sql_ast,
+                alias=f'"{alias_name}"'
+            )
+            from_exp.this.replace(sub_query_node)
+
+    sql = sql_ast.sql("duckdb")
+
+    return sql
+
+
+def get_help_text() -> str:
+    """get help text"""
+    help_text = "Available metrics:\n"
+
+    for metrics_item in METRICS_DEFINITIONS.values():
+        help_text += (
+            f"  - {metrics_item['name']}: {metrics_item['description']}\n"
+            f"    - fields: {metrics_item['fields']}\n"
+            f"    - dimensions: {metrics_item['dimensions']}\n"
+            f"    - params: {metrics_item['params']}\n"
+        )
+
+    return help_text

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,8 @@ dependencies = [
     "segment-analytics-python==2.2.3",
     "pandas",
     "pytz",
-    "kanaries_track==0.0.3"
+    "kanaries_track==0.0.3",
+    "altair>=5.0.0"
 ]
 [project.urls]
 homepage = "https://github.com/Kanaries/pygwalker"
@@ -75,6 +76,7 @@ version = { path = "pygwalker/__init__.py" }
 [tool.hatch.build]
 include = [
     "pygwalker",
+    "pygwalker_tools",
     "bin",
     "pygwalker/templates/**",
     "pygwalker/templates/**/*",
@@ -108,6 +110,7 @@ include = [
     "README.md", "LICENSE",
     "app",
     "pygwalker",
+    "pygwalker_tools",
     "bin",
     "pygwalker/templates/**",
     "pygwalker/templates/**/*",


### PR DESCRIPTION
We are trying to offer other tools, such as various metric templates, enabling users to explore the data metrics they require through setting field mapping.

for example: 

```python
from pygwalker_tools.metrics import MetricsChart
MetricsChart(
    dataset,
    {"date": "your_date_field", "user_id": "your_user_id_field", "user_signup_date": "your_user_signup_date_field"},
    params={"time_unit": "day", "time_size": 7}
).retention()
```




