### PR TITLE
simplification of default parameter

### DIFF
--- a/pygwalker/api/gradio.py
+++ b/pygwalker/api/gradio.py
@@ -17,7 +17,7 @@ def get_html_on_gradio(
     dataset: Union[DataFrame, Connector],
     gid: Union[int, str] = None,
     *,
-    fieldSpecs: Optional[Dict[str, FieldSpec]] = None,
+    field_specs: Dict[str, FieldSpec] = {},  # Use default empty dict directly
     themeKey: Literal['vega', 'g2'] = 'g2',
     dark: Literal['media', 'light', 'dark'] = 'media',
     spec: str = "",


### PR DESCRIPTION
Simplification of default parameter to 'fieldSpecs', instead of setting 'fieldSpecs' to 'none' you can directly use a default empty dictionary if the function doesn't mutate the dictionary passed by the caller