### PR TITLE
Simplified JSON encoder for handling Decimal types

### DIFF
--- a/pygwalker_tools/metrics/api.py
+++ b/pygwalker_tools/metrics/api.py
@@ -12,14 +12,10 @@ from .core import get_metrics_sql
 
 
 class _JSONEncoder(json.JSONEncoder):
-    """JSON encoder"""
     def default(self, o):
         if isinstance(o, Decimal):
-            if o.is_nan():
-                return None
             return float(o)
-
-        return json.JSONEncoder.default(self, o)
+        return super().default(o)
 
 
 def get_metrics_datas(


### PR DESCRIPTION
It checks if the object is an instance of Decimal and returns its float representation directly, this change simplifies the code by removing unnecessary checks