### PR TITLE
enhancing metricsChart class initialization

### DIFF
--- a/pygwalker_tools/metrics/api.py
+++ b/pygwalker_tools/metrics/api.py
@@ -154,7 +154,7 @@ class MetricsChart:
     ):
         self.dataset = dataset
         self.field_map = field_map
-        self.params = params
+        self.params = params if params is not None else {}
         self.reverse_axis = reverse_axis
 
     def _get_datas(self, metrics_name: str, params: Optional[Dict[str, Any]] = None) -> pd.DataFrame:


### PR DESCRIPTION
the changes ensure that self.params is always a dictionary by using a ternary operator, this avoids a potential typeError when params is none