### PR TITLE
environment display mapping error handling

### DIFF
--- a/pygwalker/api/walker.py
+++ b/pygwalker/api/walker.py
@@ -102,6 +102,9 @@ def walk(
     }
 
     display_func = env_display_map.get(env, lambda: None)
-    display_func()
+    if display_func:
+        display_func()
+    else:
+        raise ValueError(f"Unsupported environment: {env}")
 
     return walker


### PR DESCRIPTION
Making sure lambda: None fallback for display_func does not silently fail without informing the user