### PR TITLE
fix: use utc timezone when using js calculate

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -37,8 +37,8 @@
     "mobx-react-lite": "^3.4.3",
     "pako": "^2.1.0",
     "postcss": "^8.3.7",
-    "react": "^17.x",
-    "react-dom": "^17.x",
+    "react": "^18.x",
+    "react-dom": "^18.x",
     "react-syntax-highlighter": "^15.5.0",
     "styled-components": "^5.3.6",
     "tailwind-merge": "^1.14.0",
@@ -52,14 +52,20 @@
     "@rollup/plugin-terser": "^0.4.x",
     "@rollup/plugin-typescript": "^11.0.x",
     "@types/node": "^20.7.2",
-    "@types/react": "^17.x",
-    "@types/react-dom": "^17.x",
+    "@types/react": "^18.x",
+    "@types/react-dom": "^18.x",
     "@types/react-syntax-highlighter": "^15.5.7",
     "@types/styled-components": "^5.1.26",
     "@vitejs/plugin-react": "^3.1.x",
     "typescript": "^4.9.5",
     "vite": "^4.1.4",
     "vite-plugin-wasm": "^3.2.2"
+  },
+  "resolutions": {
+    "react": "^18.x",
+    "react-dom": "^18.x",
+    "@types/react": "^18.x",
+    "@types/react-dom": "^18.x"
   },
   "peerDependencies": {},
   "prettier": {

--- a/app/src/index.tsx
+++ b/app/src/index.tsx
@@ -247,7 +247,7 @@ const ExploreApp: React.FC<IAppProps> = observer((props) => {
                     enhanceAPI={enhanceAPI}
                     chart={visSpec.length === 0 ? undefined : visSpec}
                     experimentalFeatures={{ computedField: props.useKernelCalc }}
-                    defaultConfig={ props.useKernelCalc ? { config: { timezoneDisplayOffset: 0 } } : undefined}
+                    defaultConfig={{ config: { timezoneDisplayOffset: 0 } }}
                 /> :
                 <GraphicRendererApp
                     {...props}

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -2017,12 +2017,12 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.5.tgz#5f19d2b85a98e9558036f6a3cacc8819420f05cf"
   integrity sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==
 
-"@types/react-dom@^17.x":
-  version "17.0.20"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.20.tgz#e0c8901469d732b36d8473b40b679ad899da1b53"
-  integrity sha512-4pzIjSxDueZZ90F52mU3aPoogkHIoSIDG+oQ+wQK7Cy2B9S+MvOqY0uEA/qawKz381qrEDkvpwyt8Bm31I8sbA==
+"@types/react-dom@^18.x":
+  version "18.2.19"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.2.19.tgz#b84b7c30c635a6c26c6a6dfbb599b2da9788be58"
+  integrity sha512-aZvQL6uUbIJpjZk4U8JZGbau9KDeAwMfmhyWorxgBkqDIEf6ROjRozcmPIicqsUwPUjbkDfHKgGee1Lq65APcA==
   dependencies:
-    "@types/react" "^17"
+    "@types/react" "*"
 
 "@types/react-syntax-highlighter@^15.5.7":
   version "15.5.7"
@@ -2031,19 +2031,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*":
-  version "18.2.6"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.6.tgz#5cd53ee0d30ffc193b159d3516c8c8ad2f19d571"
-  integrity sha512-wRZClXn//zxCFW+ye/D2qY65UsYP1Fpex2YXorHc8awoNamkMZSvBxwxdYVInsHOZZd2Ppq8isnSzJL5Mpf8OA==
-  dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "*"
-    csstype "^3.0.2"
-
-"@types/react@^17", "@types/react@^17.x":
-  version "17.0.59"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.59.tgz#5aa4e161a356fcb824d81f166e01bad9e82243bb"
-  integrity sha512-gSON5zWYIGyoBcycCE75E9+r6dCC2dHdsrVkOEiIYNU5+Q28HcBAuqvDuxHcCbMfHBHdeT5Tva/AFn3rnMKE4g==
+"@types/react@*", "@types/react@^18.x":
+  version "18.2.62"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.62.tgz#2527a7a54749b1a99c87a4aa8b83e26846face38"
+  integrity sha512-l3f57BbaEKP0xcFzf+5qRG8/PXykZiuVM6eEoPtqBPCp6dxO3HhDkLIgIyXPhPKNAeXn3KO2pEaNgzaEo/asaw==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -4493,14 +4484,13 @@ react-color@^2.19.3:
     reactcss "^1.2.0"
     tinycolor2 "^1.4.1"
 
-react-dom@^17.x:
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"
-  integrity sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==
+react-dom@^18.x:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.2.0.tgz#22aaf38708db2674ed9ada224ca4aa708d821e3d"
+  integrity sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==
   dependencies:
     loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    scheduler "^0.20.2"
+    scheduler "^0.23.0"
 
 react-dropzone@^14.2.3:
   version "14.2.3"
@@ -4655,13 +4645,12 @@ react-use@^17.0.0:
     ts-easing "^0.2.0"
     tslib "^2.1.0"
 
-react@^17.x:
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
-  integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
+react@^18.x:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
+  integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==
   dependencies:
     loose-envify "^1.1.0"
-    object-assign "^4.1.1"
 
 reactcss@^1.2.0:
   version "1.2.3"
@@ -4813,13 +4802,12 @@ safe-buffer@^5.1.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-scheduler@^0.20.2:
-  version "0.20.2"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.2.tgz#4baee39436e34aa93b4874bddcbf0fe8b8b50e91"
-  integrity sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==
+scheduler@^0.23.0:
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.23.0.tgz#ba8041afc3d30eb206a487b6b384002e4e61fdfe"
+  integrity sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==
   dependencies:
     loose-envify "^1.1.0"
-    object-assign "^4.1.1"
 
 screenfull@^5.1.0:
   version "5.2.0"

--- a/pygwalker/api/pygwalker.py
+++ b/pygwalker/api/pygwalker.py
@@ -460,7 +460,10 @@ class PygWalker:
                 "privacy": GlobalVarManager.privacy,
             },
             "visSpec": self.vis_spec,
-            "rawFields": self.field_specs,
+            "rawFields": [
+                {**field, "offset": 0}
+                for field in self.field_specs
+            ],
             "fieldkeyGuard": False,
             "themeKey": self.theme_key,
             "dark": self.dark,

--- a/pygwalker/services/spec.py
+++ b/pygwalker/services/spec.py
@@ -134,6 +134,24 @@ def fill_new_fields(config: List[Dict[str, Any]], all_fields: List[Dict[str, str
     return config
 
 
+def _config_adapter_045a5(config: List[Dict[str, Any]]):
+    config = deepcopy(config)
+
+    for chart_item in config:
+        if "config" in chart_item and chart_item["config"].get("timezoneDisplayOffset", None) is None:
+            chart_item["config"]["timezoneDisplayOffset"] = 0
+
+        for item_list in chart_item["encodings"].values():
+            for item in item_list:
+                item["offset"] = 0
+                if isinstance(item.get("expression", {}).get("params"), list):
+                    for param in item["expression"]["params"]:
+                        if param.get("type") == "offset":
+                            param["value"] = 0
+
+    return config
+
+
 def get_spec_json(spec: str) -> Tuple[Dict[str, Any], str]:
     spec, spec_type = _get_spec_json_from_diff_source(spec)
 
@@ -153,5 +171,8 @@ def get_spec_json(spec: str) -> Tuple[Dict[str, Any], str]:
 
     if isinstance(spec_obj["config"], str):
         spec_obj["config"] = json.loads(spec_obj["config"])
+
+    if StrictVersion(spec_obj.get("version", "0.1.0")) <= StrictVersion("0.4.7a5"):
+        spec_obj["config"] = _config_adapter_045a5(spec_obj["config"])
 
     return spec_obj, spec_type


### PR DESCRIPTION
When using the same spec and the same data, the results calculated using js and calculated using python kernel are inconsistent.

The reason is that the front-end time zone and the back-end time zone are inconsistent.

This PR changes the time zone during front-end calculation to utc, which is consistent with the kernel time zone.