### PR TITLE
feat: add new api to_chart_html

### DIFF
--- a/.github/workflows/auto-ci.yml
+++ b/.github/workflows/auto-ci.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.11']
+        python-version: ['3.8', '3.11']
         os-version: [ubuntu-latest, windows-latest, macos-latest]
 
     runs-on: ${{ matrix.os-version }}

--- a/app/package.json
+++ b/app/package.json
@@ -5,7 +5,8 @@
   "license": "Apache License 2.0",
   "private": true,
   "scripts": {
-    "build": "vite build",
+    "build": "vite build && vite build --mode=dsl_to_workflow && vite build --mode=vega_to_dsl",
+    "build:app": "vite build",
     "dev:preinstall": "(cd ../graphic-walker/packages/graphic-walker; yarn --frozen-lockfile && yarn build)",
     "dev:server": "vite --host",
     "dev": "vite build --mode=develop",

--- a/app/src/lib/dslToWorkflow.ts
+++ b/app/src/lib/dslToWorkflow.ts
@@ -1,0 +1,5 @@
+import { chartToWorkflow } from '@kanaries/graphic-walker/src/utils/workflow';
+
+export default function Transform(str: string) {
+    return JSON.stringify(chartToWorkflow(JSON.parse(str)));
+}

--- a/app/src/lib/vegaToDsl.ts
+++ b/app/src/lib/vegaToDsl.ts
@@ -1,0 +1,8 @@
+import { VegaliteMapper } from '@kanaries/graphic-walker/src/lib/vl2gw';
+
+export default function Transform(str: string) {
+    const params = JSON.parse(str);
+    return JSON.stringify(
+        VegaliteMapper(...[params["vl"], params["allFields"], params["visId"], params["name"]])
+    );
+}

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -5,8 +5,6 @@ import react from '@vitejs/plugin-react'
 import typescript from '@rollup/plugin-typescript'
 import { peerDependencies } from './package.json'
 import Replace from '@rollup/plugin-replace'
-import CommonJs from '@rollup/plugin-commonjs'
-import Terser from '@rollup/plugin-terser'
 
 // @see https://styled-components.com/docs/faqs#marking-styledcomponents-as-external-in-your-package-dependencies
 const modulesNotToBundle = Object.keys(peerDependencies);
@@ -14,6 +12,43 @@ const modulesNotToBundle = Object.keys(peerDependencies);
 // https://vitejs.dev/config/
 export default defineConfig((config: ConfigEnv) => {
   console.log("defineConfig: ", config);
+
+  const buildConfigMap = {
+    "production": {
+      lib: {
+        entry: path.resolve(__dirname, './src/index.tsx'),
+        name: 'PyGWalkerApp',
+        fileName: (format) => `pygwalker-app.${format}.js`,
+        formats: ['iife']
+      },
+      minify: 'esbuild',
+      sourcemap: false,
+      outDir: '../pygwalker/templates/dist'
+    },
+    "dsl_to_workflow": {
+      lib: {
+        entry: path.resolve(__dirname, "./src/lib/dslToWorkflow.ts"),
+        name: "main",
+        formats: ["umd"],
+        fileName: (format) => `dsl-to-workflow.${format}.js`,
+      },
+      minify: "esbuild",
+      sourcemap: false,
+      outDir: '../pygwalker/templates/dist'
+    },
+    "vega_to_dsl": {
+      lib: {
+        entry: path.resolve(__dirname, "./src/lib/vegaToDsl.ts"),
+        name: "main",
+        formats: ["umd"],
+        fileName: (format) => `vega-to-dsl.${format}.js`,
+      },
+      minify: "esbuild",
+      sourcemap: false,
+      outDir: '../pygwalker/templates/dist'
+    }
+  }
+
   return {
     server: {
       port: 2002,
@@ -32,34 +67,12 @@ export default defineConfig((config: ConfigEnv) => {
         'process.env.NODE_ENV': JSON.stringify(config.mode),
         'preventAssignment': true
       }),
-      ... (config.mode === 'production') ? [CommonJs(), Terser()]: []
     ],
     resolve: {
       alias: {
         "@": path.resolve(__dirname, "./src"),
       },
     },
-    build: {
-      lib: {
-        entry: path.resolve(__dirname, './src/index.tsx'),
-        name: 'PyGWalkerApp',
-        fileName: (format) => `pygwalker-app.${format}.js`,
-        formats: ['iife']
-      },
-      rollupOptions: {
-        // external: modulesNotToBundle,
-        // output: {
-        //   globals: {
-        //     'react': 'React',
-        //     'react-dom': 'ReactDOM',
-        //     'styled-components': 'styled',
-        //   },
-        // },
-      },
-      minify: 'terser', // 'esbuild',
-      // sourcemap: true,
-      sourcemap: false,
-      outDir: '../pygwalker/templates/dist'
-    }
+    build: buildConfigMap[config.mode]
   } as UserConfig;
 })

--- a/pygwalker/__init__.py
+++ b/pygwalker/__init__.py
@@ -10,7 +10,7 @@ from pygwalker.utils.execute_env_check import check_kaggle as __check_kaggle
 from pygwalker.services.global_var import GlobalVarManager
 from pygwalker.services.kaggle import show_tips_user_kaggle as __show_tips_user_kaggle
 
-__version__ = "0.4.7a6"
+__version__ = "0.4.7a7"
 __hash__ = __rand_str()
 
 from pygwalker.api.jupyter import walk, render, table

--- a/pygwalker/api/html.py
+++ b/pygwalker/api/html.py
@@ -1,11 +1,14 @@
-from typing import Union, Dict, Optional
+from typing import Union, Dict, Optional, Any
 import logging
 import traceback
 
 from typing_extensions import Literal
 
 from .pygwalker import PygWalker
+from pygwalker.services.data_parsers import get_parser
+from pygwalker.services.preview_image import render_gw_chart_preview_html
 from pygwalker.data_parsers.base import FieldSpec
+from pygwalker.data_parsers.database_parser import Connector
 from pygwalker._typing import DataFrame
 from pygwalker.utils.randoms import generate_hash_code
 from pygwalker.utils.check_walker_params import check_expired_params
@@ -71,3 +74,45 @@ def to_html(
         logger.error(traceback.format_exc())
         return f"<div>{str(e)}</div>"
     return html
+
+
+def to_chart_html(
+    dataset: Union[DataFrame, Connector, str],
+    spec: Dict[str, Any],
+    *,
+    spec_type: Literal["graphic-walker", "vega"] = "graphic-walker",
+    theme_key: Literal['vega', 'g2'] = 'g2',
+    dark: Literal['media', 'light', 'dark'] = 'media',
+) -> str:
+    """
+    Generate HTML code of a chart by graphic-walker or vega spec.
+
+    Args:
+        - dataset (pl.DataFrame | pd.DataFrame | Connector, optional): dataset.
+        - spec (Dict[str, Any]): chart config data.
+
+    Kargs:
+        - spec_type (Literal["graphic-walker", "vega"]): type of spec.
+        - theme_key ('vega' | 'g2'): theme type.
+        - dark ('media' | 'light' | 'dark'): 'media': auto detect OS theme.
+    """
+    # pylint: disable=import-outside-toplevel
+    # Since the compatibility of quick js is not certain, the related methods are lazy loaded.
+    from pygwalker.utils.dsl_transform import vega_to_dsl, dsl_to_workflow
+
+    data_parser = get_parser(dataset)
+    if spec_type == "vega":
+        gw_dsl = vega_to_dsl(spec, data_parser.raw_fields)
+    else:
+        gw_dsl = spec
+    workflow = dsl_to_workflow(gw_dsl)
+
+    data = data_parser.get_datas_by_payload(workflow)
+    return render_gw_chart_preview_html(
+        single_vis_spec=gw_dsl,
+        data=data,
+        theme_key=theme_key,
+        dark=dark,
+        title="",
+        desc=""
+    )

--- a/pygwalker/utils/dsl_transform.py
+++ b/pygwalker/utils/dsl_transform.py
@@ -1,0 +1,28 @@
+from typing import Dict, List, Any
+import os
+import json
+
+from quickjs import Function
+
+from pygwalker._constants import ROOT_DIR
+from .randoms import rand_str
+
+
+with open(os.path.join(ROOT_DIR, 'templates', 'dist', 'dsl-to-workflow.umd.js'), 'r', encoding='utf8') as f:
+    _dsl_to_workflow_js = Function('main', f.read())
+
+with open(os.path.join(ROOT_DIR, 'templates', 'dist', 'vega-to-dsl.umd.js'), 'r', encoding='utf8') as f:
+    _vega_to_dsl_js = Function('main', f.read())
+
+
+def dsl_to_workflow(dsl: Dict[str, Any]) -> Dict[str, Any]:
+    return json.loads(_dsl_to_workflow_js(json.dumps(dsl)))
+
+
+def vega_to_dsl(vega_config: Dict[str, Any], fields: List[Dict[str, Any]]) -> Dict[str, Any]:
+    return json.loads(_vega_to_dsl_js(json.dumps({
+        "vl": vega_config,
+        "allFields": fields,
+        "visId": rand_str(6),
+        "name": rand_str(6)
+    })))

--- a/pygwalker_tools/metrics/api.py
+++ b/pygwalker_tools/metrics/api.py
@@ -1,14 +1,37 @@
+"""
+Experimental features
+"""
 from typing import List, Dict, Any, Union, Optional
 from decimal import Decimal
 import json
 
-import altair as alt
 import pandas as pd
 
 from pygwalker._typing import DataFrame
 from pygwalker.data_parsers.database_parser import Connector
 from pygwalker.services.data_parsers import get_parser
+from pygwalker.api.html import to_chart_html
 from .core import get_metrics_sql
+
+
+class Chart:
+    """Chart"""
+    def __init__(self, data: DataFrame, spec: Dict[str, Any]):
+        self._html = to_chart_html(
+            data,
+            spec,
+            spec_type="vega"
+        )
+
+    @property
+    def html(self) -> str:
+        return self._html
+
+    def __str__(self) -> str:
+        return self._html
+
+    def _repr_html_(self):
+        return self._html
 
 
 class _JSONEncoder(json.JSONEncoder):
@@ -171,62 +194,62 @@ class MetricsChart:
             encode_params["x"], encode_params["y"] = encode_params["y"], encode_params["x"]
         return encode_params
 
-    def pv(self) -> alt.Chart:
+    def pv(self) -> Chart:
         datas = self._get_datas("pv")
-        encode_params = {
-            "x": "date",
-            "y": "pv",
-            "tooltip": ["date", "pv"]
+        params = {
+            "mark": "line",
+            "encoding": {
+                "x": {"field": "date"},
+                "y": {"field": "pv"},
+            }
         }
-        return alt.Chart(datas).mark_line().encode(
-            **self._format_encode(encode_params)
-        )
+        return Chart(datas, params)
 
-    def uv(self) -> alt.Chart:
+    def uv(self) -> Chart:
         datas = self._get_datas("uv")
-        encode_params = {
-            "x": "date",
-            "y": "uv",
-            "tooltip": ["date", "uv"]
+        params = {
+            "mark": "line",
+            "encoding": {
+                "x": {"field": "date"},
+                "y": {"field": "uv"},
+            }
         }
-        return alt.Chart(datas).mark_line().encode(
-            **self._format_encode(encode_params)
-        )
+        return Chart(datas, params)
 
-    def mau(self) -> alt.Chart:
+    def mau(self) -> Chart:
         datas = self._get_datas("mau")
-        encode_params = {
-            "x": "date",
-            "y": "mau",
-            "tooltip": ["date", "mau"]
+        params = {
+            "mark": "line",
+            "encoding": {
+                "x": {"field": "date"},
+                "y": {"field": "mau"},
+            }
         }
-        return alt.Chart(datas).mark_line().encode(
-            **self._format_encode(encode_params)
-        )
+        return Chart(datas, params)
 
-    def retention(self) -> alt.Chart:
+    def retention(self) -> Chart:
         datas = self._get_datas("retention")
-        encode_params = {
-            "x": "date",
-            "y": "retention",
-            "tooltip": ["date", "retention"]
+        params = {
+            "mark": "line",
+            "encoding": {
+                "x": {"field": "date"},
+                "y": {"field": "retention"},
+            }
         }
-        return alt.Chart(datas).mark_line().encode(
-            **self._format_encode(encode_params)
-        )
+        return Chart(datas, params)
 
-    def new_user_count(self) -> alt.Chart:
+    def new_user_count(self) -> Chart:
         datas = self._get_datas("new_user_count")
-        encode_params = {
-            "x": "date",
-            "y": "new_user_count",
-            "tooltip": ["date", "new_user_count"],
+        params = {
+            "mark": "line",
+            "encoding": {
+                "x": {"field": "date"},
+                "y": {"field": "new_user_count"},
+            }
         }
-        return alt.Chart(datas).mark_bar().encode(
-            **self._format_encode(encode_params)
-        )
+        return Chart(datas, params)
 
-    def cohort_matrix(self) -> alt.Chart:
+    def cohort_matrix(self) -> Chart:
         all_df = []
         for i in range(1, 31):
             df = self._get_datas("retention", {"time_unit": "day", "time_size": i})
@@ -234,34 +257,34 @@ class MetricsChart:
             all_df.append(df)
 
         datas = pd.concat(all_df)
-        encode_params = {
-            "x": "time_size:O",
-            "y": "date:O",
-            "color": "retention",
-            "tooltip": ["date", "time_size", "retention"]
+        params = {
+            "mark": "rect",
+            "encoding": {
+                "x": {"field": "date", "type": "ordinal"},
+                "y": {"field": "new_user_count", "type": "ordinal"},
+                "color": {"field": "retention"},
+            }
         }
-        return alt.Chart(datas).mark_rect().encode(
-            **self._format_encode(encode_params)
-        )
+        return Chart(datas, params)
 
-    def active_user_count(self) -> alt.Chart:
+    def active_user_count(self) -> Chart:
         datas = self._get_datas("active_user_count")
-        encode_params = {
-            "x": "date",
-            "y": "active_user_count",
-            "tooltip": ["date", "active_user_count"],
+        params = {
+            "mark": "bar",
+            "encoding": {
+                "x": {"field": "date"},
+                "y": {"field": "active_user_count"},
+            }
         }
-        return alt.Chart(datas).mark_bar().encode(
-            **self._format_encode(encode_params)
-        )
+        return Chart(datas, params)
 
-    def user_churn_rate_base_active(self) -> alt.Chart:
+    def user_churn_rate_base_active(self):
         datas = self._get_datas("user_churn_rate_base_active")
-        encode_params = {
-            "x": "date",
-            "y": "user_churn_rate",
-            "tooltip": ["date", "user_churn_rate"],
+        params = {
+            "mark": "line",
+            "encoding": {
+                "x": {"field": "date"},
+                "y": {"field": "user_churn_rate"},
+            }
         }
-        return alt.Chart(datas).mark_line().encode(
-            **self._format_encode(encode_params)
-        )
+        return Chart(datas, params)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,8 @@ dependencies = [
     "pandas",
     "pytz",
     "kanaries_track==0.0.4",
-    "altair>=5.0.0",
     "cachetools",
+    "quickjs",
 ]
 [project.urls]
 homepage = "https://github.com/Kanaries/pygwalker"


### PR DESCRIPTION
### new api `to_chart_html`

**API Reference**

```python
def to_chart_html(
    dataset: Union[DataFrame, Connector, str],
    spec: Dict[str, Any],
    *,
    spec_type: Literal["graphic-walker", "vega"] = "graphic-walker",
    theme_key: Literal['vega', 'g2'] = 'g2',
    dark: Literal['media', 'light', 'dark'] = 'media',
) -> str:
    """
    Generate HTML code of a chart by graphic-walker or vega spec.

    Args:
        - dataset (pl.DataFrame | pd.DataFrame | Connector, optional): dataset.
        - spec (Dict[str, Any]): chart config data.

    Kargs:
        - spec_type (Literal["graphic-walker", "vega"]): type of spec.
        - theme_key ('vega' | 'g2'): theme type.
        - dark ('media' | 'light' | 'dark'): 'media': auto detect OS theme.
    """
    pass
```

**Example**

```python
from pygwalker.api.html import to_chart_html
from IPython.display import display, HTML

html = to_chart_html(
    df,
    {
        "mark": "bar",
        "encoding": {
            "x": {"field": "season"},
            "y": {"field": "casual", "aggregate": "sum"},
            "color": {"field": "holiday"},
        }
    },
    spec_type="vega"
)

display(HTML(html))
```

![image](https://github.com/Kanaries/pygwalker/assets/28337703/b7a53d86-9879-4301-97c8-024eebf5f6c7)
