### PR TITLE
refactor: use spec_io_mode instead of debug parameter

### DIFF
--- a/pygwalker/api/gradio.py
+++ b/pygwalker/api/gradio.py
@@ -22,7 +22,7 @@ def get_html_on_gradio(
     theme_key: Literal['vega', 'g2'] = 'g2',
     dark: Literal['media', 'light', 'dark'] = 'media',
     spec: str = "",
-    debug: bool = False,
+    spec_io_mode: Literal["r", "rw"] = "r",
     use_kernel_calc: bool = True,
     kanaries_api_key: str = "",
     default_tab: Literal["data", "vis"] = "vis",
@@ -40,7 +40,7 @@ def get_html_on_gradio(
         - theme_key ('vega' | 'g2'): theme type.
         - dark (Literal['media' | 'light' | 'dark']): 'media': auto detect OS theme.
         - spec (str): chart config data. config id, json, remote file url
-        - debug (bool): Whether to use debug mode, Default to False.
+        - spec_io_mode (Literal["r", "rw"]): spec io mode, Default to "r", "r" for read, "rw" for read and write.
         - use_kernel_calc(bool): Whether to use kernel compute for datas, Default to True.
         - kanaries_api_key (str): kanaries api key, Default to "".
         - default_tab (Literal["data", "vis"]): default tab to show. Default to "vis"
@@ -58,7 +58,7 @@ def get_html_on_gradio(
         show_cloud_tool=False,
         use_preview=False,
         use_kernel_calc=isinstance(dataset, Connector) or use_kernel_calc,
-        use_save_tool=debug,
+        use_save_tool="w" in spec_io_mode,
         is_export_dataframe=False,
         kanaries_api_key=kanaries_api_key,
         default_tab=default_tab,

--- a/pygwalker/api/streamlit.py
+++ b/pygwalker/api/streamlit.py
@@ -59,7 +59,7 @@ class StreamlitRenderer:
         theme_key: Literal['vega', 'g2'] = 'g2',
         dark: Literal['media', 'light', 'dark'] = 'media',
         spec: str = "",
-        debug: bool = False,
+        spec_io_mode: Literal["r", "rw"] = "r",
         use_kernel_calc: Optional[bool] = True,
         show_cloud_tool: Optional[bool] = None,
         kanaries_api_key: str = "",
@@ -78,7 +78,7 @@ class StreamlitRenderer:
             - theme_key ('vega' | 'g2'): theme type.
             - dark (Literal['media' | 'light' | 'dark']): 'media': auto detect OS theme.
             - spec (str): chart config data. config id, json, remote file url
-            - debug (bool): Whether to use debug mode, Default to False.
+            - spec_io_mode (Literal["r", "rw"]): spec io mode, Default to "r", "r" for read, "rw" for read and write.
             - use_kernel_calc(bool): Whether to use kernel compute for datas, Default to True.
             - kanaries_api_key (str): kanaries api key, Default to "".
             - default_tab (Literal["data", "vis"]): default tab to show. Default to "vis"
@@ -98,7 +98,7 @@ class StreamlitRenderer:
             show_cloud_tool=show_cloud_tool,
             use_preview=False,
             use_kernel_calc=isinstance(dataset, Connector) or use_kernel_calc,
-            use_save_tool=debug,
+            use_save_tool="w" in spec_io_mode,
             is_export_dataframe=False,
             kanaries_api_key=kanaries_api_key,
             default_tab=default_tab,
@@ -270,7 +270,7 @@ def get_streamlit_html(
     spec: str = "",
     use_kernel_calc: Optional[bool] = None,
     show_cloud_tool: Optional[bool] = None,
-    debug: bool = False,
+    spec_io_mode: Literal["r", "rw"] = "r",
     kanaries_api_key: str = "",
     mode: Literal["explore", "filter_renderer"] = "explore",
     default_tab: Literal["data", "vis"] = "vis",
@@ -288,7 +288,7 @@ def get_streamlit_html(
         - dark (Literal['media' | 'light' | 'dark']): 'media': auto detect OS theme.
         - spec (str): chart config data. config id, json, remote file url
         - use_kernel_calc(bool): Whether to use kernel compute for datas, Default to None.
-        - debug (bool): Whether to use debug mode, Default to False.
+        - spec_io_mode (Literal["r", "rw"]): spec io mode, Default to "r", "r" for read, "rw" for read and write.
         - kanaries_api_key (str): kanaries api key, Default to "".
         - default_tab (Literal["data", "vis"]): default tab to show. Default to "vis"
     """
@@ -302,7 +302,7 @@ def get_streamlit_html(
         spec=spec,
         theme_key=theme_key,
         dark=dark,
-        debug=debug,
+        spec_io_mode=spec_io_mode,
         use_kernel_calc=use_kernel_calc,
         show_cloud_tool=show_cloud_tool,
         kanaries_api_key=kanaries_api_key,

--- a/pygwalker/utils/check_walker_params.py
+++ b/pygwalker/utils/check_walker_params.py
@@ -8,6 +8,7 @@ def check_expired_params(params: Dict[str, Any]):
     expired_params_map = {
         "fieldSpecs": "field_specs",
         "themeKey": "theme_key",
+        "debug": "spec_io_mode",
     }
 
     for old_param, new_param in expired_params_map.items():


### PR DESCRIPTION
The previous 'debug' parameter was only used to restrict the ability to read and write spec files. We believe this parameter name is not meaningful, and we are replacing it with 'spec_io_mode.'

The 'spec_io_mode' parameter currently has two options: 'r' and 'wr,' where 'r' indicates that the spec is read-only, and 'wr' indicates that spec files can be saved.

previous:
```python
StreamlitRenderer(df, spec="./gw_config.json", debug=True)
```

current:
```python
StreamlitRenderer(df, spec="./gw_config.json", spec_io_mode="wr")
```