### PR TITLE
feat: add new html apis

### DIFF
--- a/pygwalker/api/html.py
+++ b/pygwalker/api/html.py
@@ -1,6 +1,5 @@
 from typing import Union, Dict, Optional, Any
 import logging
-import traceback
 
 from typing_extensions import Literal
 
@@ -16,7 +15,7 @@ from pygwalker.utils.check_walker_params import check_expired_params
 logger = logging.getLogger(__name__)
 
 
-def to_html(
+def _to_html(
     df: DataFrame,
     gid: Union[int, str] = None,
     *,
@@ -25,20 +24,13 @@ def to_html(
     theme_key: Literal['vega', 'g2'] = 'g2',
     dark: Literal['media', 'light', 'dark'] = 'media',
     default_tab: Literal["data", "vis"] = "vis",
+    gw_mode: Literal['explore', 'renderer', 'filter_renderer', 'table'] = "explore",
+    width: Optional[int] = None,
+    height: Optional[int] = None,
     **kwargs
-):
+) -> str:
     """
     Generate embeddable HTML code of Graphic Walker with data of `df`.
-
-    Args:
-        - df (pl.DataFrame | pd.DataFrame, optional): dataframe.
-        - gid (Union[int, str], optional): GraphicWalker container div's id ('gwalker-{gid}')
-
-    Kargs:
-        - field_specs (Dict[str, FieldSpec], optional): Specifications of some fields. They'll been automatically inferred from `df` if some fields are not specified.
-        - spec (str): chart config data. config id, json, remote file url
-        - theme_key ('vega' | 'g2'): theme type.
-        - dark ('media' | 'light' | 'dark'): 'media': auto detect OS theme.
     """
     check_expired_params(kwargs)
 
@@ -60,7 +52,7 @@ def to_html(
         use_preview=False,
         use_kernel_calc=False,
         use_save_tool=False,
-        gw_mode="explore",
+        gw_mode=gw_mode,
         is_export_dataframe=False,
         kanaries_api_key="",
         default_tab=default_tab,
@@ -68,12 +60,103 @@ def to_html(
         **kwargs
     )
 
-    try:
-        html = walker.to_html()
-    except Exception as e:
-        logger.error(traceback.format_exc())
-        return f"<div>{str(e)}</div>"
-    return html
+    return walker.to_html(width, height)
+
+
+def to_html(
+    df: DataFrame,
+    gid: Union[int, str] = None,
+    *,
+    spec: str = "",
+    field_specs: Optional[Dict[str, FieldSpec]] = None,
+    theme_key: Literal['vega', 'g2'] = 'g2',
+    dark: Literal['media', 'light', 'dark'] = 'media',
+    default_tab: Literal["data", "vis"] = "vis",
+    **kwargs
+) -> str:
+    """
+    Generate embeddable HTML code of Graphic Walker with data of `df`.
+
+    Args:
+        - df (pl.DataFrame | pd.DataFrame, optional): dataframe.
+        - gid (Union[int, str], optional): GraphicWalker container div's id ('gwalker-{gid}')
+
+    Kargs:
+        - field_specs (List[FieldSpec], optional): Specifications of some fields. They'll been automatically inferred from `df` if some fields are not specified.
+        - spec (str): chart config data. config id, json, remote file url
+        - theme_key ('vega' | 'g2'): theme type.
+        - dark ('media' | 'light' | 'dark'): 'media': auto detect OS theme.
+        - default_tab (Literal["data", "vis"]): default tab to show. Default to "vis"
+    """
+    return _to_html(
+        df,
+        gid,
+        spec=spec,
+        field_specs=field_specs,
+        theme_key=theme_key,
+        dark=dark,
+        default_tab=default_tab,
+        **kwargs
+    )
+
+
+def to_table_html(
+    df: DataFrame,
+    *,
+    theme_key: Literal['vega', 'g2'] = 'g2',
+    dark: Literal['media', 'light', 'dark'] = 'media',
+    **kwargs
+) -> str:
+    """
+    Generate embeddable HTML code of Graphic Walker with data of `df`.
+
+    Args:
+        - df (pl.DataFrame | pd.DataFrame, optional): dataframe.
+
+    Kargs:
+        - theme_key ('vega' | 'g2'): theme type.
+        - dark ('media' | 'light' | 'dark'): 'media': auto detect OS theme.
+    """
+    return _to_html(
+        df,
+        None,
+        spec="",
+        field_specs={},
+        theme_key=theme_key,
+        dark=dark,
+        gw_mode="table",
+        height="800px",
+        **kwargs
+    )
+
+
+def to_render_html(
+    df: DataFrame,
+    spec: str,
+    *,
+    theme_key: Literal['vega', 'g2'] = 'g2',
+    dark: Literal['media', 'light', 'dark'] = 'media',
+    **kwargs
+) -> str:
+    """
+    Args:
+        - df (pl.DataFrame | pd.DataFrame, optional): dataframe.
+        - spec (str): chart config data. config id, json, remote file url
+
+    Kargs:
+        - theme_key ('vega' | 'g2'): theme type.
+        - dark ('media' | 'light' | 'dark'): 'media': auto detect OS theme.
+    """
+    return _to_html(
+        df,
+        None,
+        spec=spec,
+        field_specs={},
+        theme_key=theme_key,
+        dark=dark,
+        gw_mode="filter_renderer",
+        **kwargs
+    )
 
 
 def to_chart_html(

--- a/pygwalker/api/pygwalker.py
+++ b/pygwalker/api/pygwalker.py
@@ -180,9 +180,9 @@ class PygWalker:
             for key, value in chart_map_dict.items()
         }
 
-    def to_html(self) -> str:
+    def to_html(self, iframe_width: Optional[str] = None, iframe_height: Optional[str] = None) -> str:
         props = self._get_props()
-        return self._get_render_iframe(props)
+        return self._get_render_iframe(props, iframe_width=iframe_width, iframe_height=iframe_height)
 
     def to_html_without_iframe(self) -> str:
         props = self._get_props()
@@ -225,7 +225,7 @@ class PygWalker:
         else:
             display_html(iframe_html)
 
-    def display_on_jupyter_use_widgets(self, iframe_height: str = "1010px"):
+    def display_on_jupyter_use_widgets(self, iframe_width: Optional[str] = None, iframe_height: Optional[str] = None):
         """
         use ipywidgets, Display on jupyter notebook/lab.
         When the kernel is down, the chart will not be displayed, so use `display_on_jupyter` to share
@@ -238,7 +238,7 @@ class PygWalker:
             data_source,
             len(self.origin_data_source) > len(data_source)
         )
-        iframe_html = self._get_render_iframe(props, iframe_height=iframe_height)
+        iframe_html = self._get_render_iframe(props, iframe_width=iframe_width, iframe_height=iframe_height)
 
         html_widgets = ipywidgets.Box(
             [ipywidgets.HTML(iframe_html), comm.get_widgets()],
@@ -545,12 +545,13 @@ class PygWalker:
         self,
         props: Dict[str, Any],
         return_iframe: bool = True,
-        iframe_height: str = "1010px"
+        iframe_width: Optional[str] = None,
+        iframe_height: Optional[str] = None
     ) -> str:
         html = render_gwalker_html(self.gid, props)
         if return_iframe:
             srcdoc = m_html.escape(html)
-            return render_gwalker_iframe(self.gid, srcdoc, iframe_height)
+            return render_gwalker_iframe(self.gid, srcdoc, iframe_width, iframe_height)
         else:
             return html
 

--- a/pygwalker/services/render.py
+++ b/pygwalker/services/render.py
@@ -1,7 +1,7 @@
 import os
 import json
 import base64
-from typing import Dict, List, Any
+from typing import Dict, List, Any, Optional
 
 from jinja2 import Environment, PackageLoader
 
@@ -28,11 +28,22 @@ def get_max_limited_datas(datas: List[Dict[str, Any]], byte_limit: int) -> List[
     return datas
 
 
-def render_gwalker_iframe(gid: int, srcdoc: str, height: str) -> str:
+def render_gwalker_iframe(
+    gid: int,
+    srcdoc: str,
+    width: Optional[str] = None,
+    height: Optional[str] = None
+) -> str:
+    if height is None:
+        height = "1010px"
+    if width is None:
+        width = "100%"
+
     return jinja_env.get_template("pygwalker_iframe.html").render(
         gid=gid,
         srcdoc=srcdoc,
         height=height,
+        width=width
     )
 
 

--- a/pygwalker/templates/pygwalker_iframe.html
+++ b/pygwalker/templates/pygwalker_iframe.html
@@ -3,7 +3,7 @@
         <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
     </head>
     <iframe
-        width="100%"
+        width="{{ width }}"
         height="{{ height }}"
         id="gwalker-{{ gid }}"
         srcdoc="{{ srcdoc }}"


### PR DESCRIPTION
## to_table_html

```python
def to_table_html(
    df: DataFrame,
    *,
    theme_key: Literal['vega', 'g2'] = 'g2',
    dark: Literal['media', 'light', 'dark'] = 'media',
    **kwargs
) -> str:
    """
    Generate embeddable HTML code of Graphic Walker with data of `df`.

    Args:
        - df (pl.DataFrame | pd.DataFrame, optional): dataframe.

    Kargs:
        - theme_key ('vega' | 'g2'): theme type.
        - dark ('media' | 'light' | 'dark'): 'media': auto detect OS theme.
    """
    pass
```

* example

```python
from pygwalker.api.html import to_table_html

with open("pyg_table.html", "w") as f:
    f.write(to_table_html(df))
```

##  to_render_html

```python
def to_render_html(
    df: DataFrame,
    spec: str,
    *,
    theme_key: Literal['vega', 'g2'] = 'g2',
    dark: Literal['media', 'light', 'dark'] = 'media',
    **kwargs
) -> str:
    """
    Args:
        - df (pl.DataFrame | pd.DataFrame, optional): dataframe.
        - spec (str): chart config data. config id, json, remote file url

    Kargs:
        - theme_key ('vega' | 'g2'): theme type.
        - dark ('media' | 'light' | 'dark'): 'media': auto detect OS theme.
    """
    pass
```

* example

```python
from pygwalker.api.html import to_table_html

with open("pyg_render.html", "w") as f:
    f.write(to_render_html(df))
```