### PR TITLE
feat: support vega spec

### DIFF
--- a/app/src/index.tsx
+++ b/app/src/index.tsx
@@ -45,6 +45,7 @@ import { SunIcon, MoonIcon, DesktopIcon } from "@radix-ui/react-icons"
 import style from './index.css?inline'
 import { currentMediaTheme } from './utils/theme';
 import { AppContext, darkModeContext } from './store/context';
+import FormatSpec from './utils/formatSpec';
 
 
 const initChart = async (gwRef: React.MutableRefObject<IGWHandler | null>, total: number, props: IAppProps) => {
@@ -275,7 +276,7 @@ const initOnJupyter = async(props: IAppProps) => {
     communicationStore.setComm(comm);
     if (props.needLoadLastSpec) {
         const visSpecResp = await comm.sendMsg("get_latest_vis_spec", {});
-        props.visSpec = visSpecResp["data"]["visSpec"];
+        props.visSpec = FormatSpec(visSpecResp["data"]["visSpec"], props.rawFields);
     }
     if (props.needLoadDatas) {
         comm.sendMsgAsync("request_data", {}, null);
@@ -326,6 +327,7 @@ function GWalkerComponent(props: IAppProps) {
 }
 
 function GWalker(props: IAppProps, id: string) {
+    props.visSpec = FormatSpec(props.visSpec, props.rawFields);
     let preRender = defaultInit;
     switch(props.env) {
         case "jupyter_widgets":
@@ -352,6 +354,8 @@ function GWalker(props: IAppProps, id: string) {
 }
 
 function PreviewApp(props: IPreviewProps, id: string) {
+    props.charts = FormatSpec(props.charts.map(chart => chart.visSpec), [])
+                    .map((visSpec, index) => { return {...props.charts[index], visSpec} });
     ReactDOM.render(
         <MainApp darkMode={props.dark} hideToolBar>
             <Preview {...props} />
@@ -361,6 +365,7 @@ function PreviewApp(props: IPreviewProps, id: string) {
 }
 
 function ChartPreviewApp(props: IChartPreviewProps, id: string) {
+    props.visSpec = FormatSpec(props.visSpec, []);
     ReactDOM.render(
         <MainApp darkMode={props.dark} hideToolBar>
             <ChartPreview {...props} />

--- a/app/src/utils/formatSpec.ts
+++ b/app/src/utils/formatSpec.ts
@@ -1,0 +1,12 @@
+import { VegaliteMapper } from '@kanaries/graphic-walker/src/lib/vl2gw';
+
+export default function FormatSpec(spec: any[], fields: any[]) {
+    return spec.map((item, index) => {
+        if (["config", "encodings", "visId"].every(key => item.hasOwnProperty(key))) {
+            return item;
+        } else {
+            const result = VegaliteMapper(item, fields, Math.random().toString(16).split(".").at(1)!, `Chart ${index+1}`);
+            return result;
+        }
+    })
+}

--- a/pygwalker/__init__.py
+++ b/pygwalker/__init__.py
@@ -10,7 +10,7 @@ from pygwalker.utils.execute_env_check import check_kaggle as __check_kaggle
 from pygwalker.services.global_var import GlobalVarManager
 from pygwalker.services.kaggle import show_tips_user_kaggle as __show_tips_user_kaggle
 
-__version__ = "0.4.8a1"
+__version__ = "0.4.8a2"
 __hash__ = __rand_str()
 
 from pygwalker.api.jupyter import walk, render, table

--- a/pygwalker/api/pygwalker.py
+++ b/pygwalker/api/pygwalker.py
@@ -155,7 +155,10 @@ class PygWalker:
 
     def _init_spec(self, spec: Dict[str, Any], field_specs: List[FieldSpec]):
         spec_obj, spec_type = get_spec_json(spec)
-        self._update_vis_spec(spec_obj["config"] and fill_new_fields(spec_obj["config"], field_specs))
+        if spec_type.startswith("vega"):
+            self._update_vis_spec(spec_obj["config"])
+        else:
+            self._update_vis_spec(spec_obj["config"] and fill_new_fields(spec_obj["config"], field_specs))
         self.spec_type = spec_type
         self._chart_map = self._parse_chart_map_dict(spec_obj["chart_map"])
         self.spec_version = spec_obj.get("version", None)
@@ -166,6 +169,7 @@ class PygWalker:
         self._chart_name_index_map = {
             item["name"]: index
             for index, item in enumerate(vis_spec)
+            if "name" in item
         }
 
     def _get_chart_map_dict(self, chart_map: Dict[str, ChartData]) -> Dict[str, Any]:


### PR DESCRIPTION
users can initialize graphic-walker through vega config.

```python
vega_sepc = {
  "mark": "bar",
  "encoding": {
    "x": {"field": "season", "type": "nominal", "axis": {"labelAngle": 0}},
    "y": {"field": "casual", "type": "quantitative", "aggregate": "sum"}
  }
}

walker = pyg.walk(df, spec=vega_sepc)
```

![image](https://github.com/Kanaries/pygwalker/assets/28337703/727f1b49-5020-41da-9044-4dc86f537158)

