### PR TITLE
fix: temporarily fix bugs of pure chart rendering in streamlit

### DIFF
--- a/app/src/tools/saveTool.tsx
+++ b/app/src/tools/saveTool.tsx
@@ -59,6 +59,13 @@ export function getSaveTool(
             if (visSpec === undefined) {
                 throw new Error("visSpec is undefined");
             }
+            if (storeRef.current?.visIndex !== undefined) {
+                const currentChart = visSpec[storeRef.current?.visIndex];
+                if (currentChart.layout.size.mode === "auto") {
+                    currentChart.layout.size.width = chartData.container()?.clientWidth || 320;
+                    currentChart.layout.size.height = chartData.container()?.clientHeight || 200;
+                }
+            }
             await communicationStore.comm?.sendMsg("update_spec", {
                 "visSpec": visSpec,
                 "chartData": await formatExportedChartDatas(chartData),

--- a/pygwalker/__init__.py
+++ b/pygwalker/__init__.py
@@ -10,7 +10,7 @@ from pygwalker.utils.execute_env_check import check_kaggle as __check_kaggle
 from pygwalker.services.global_var import GlobalVarManager
 from pygwalker.services.kaggle import show_tips_user_kaggle as __show_tips_user_kaggle
 
-__version__ = "0.4.8a2"
+__version__ = "0.4.8a3"
 __hash__ = __rand_str()
 
 from pygwalker.api.jupyter import walk, render, table


### PR DESCRIPTION
When the size mode of the chart is auto, python-end has no way to know the size of the chart that needs to be rendered.

```json
{
    "size": {
      "mode": "auto",
      "width": 151,
      "height": 548
    }
}
```

When users click save icon, the real size of chart that will be written to the config.
