### PR TITLE
fix: update graphic walker to 0.4.56

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@headlessui/react": "^1.7.14",
     "@heroicons/react": "^2.0.8",
-    "@kanaries/graphic-walker": "0.4.55",
+    "@kanaries/graphic-walker": "0.4.56",
     "@kanaries/gw-dsl-parser": "0.1.45-rc6",
     "@radix-ui/react-checkbox": "^1.0.4",
     "@radix-ui/react-dialog": "^1.0.5",
@@ -58,7 +58,7 @@
     "@types/react-syntax-highlighter": "^15.5.7",
     "@types/styled-components": "^5.1.26",
     "@vitejs/plugin-react": "^3.1.x",
-    "typescript": "^4.9.5",
+    "typescript": "^5.4.2",
     "vite": "^4.1.4",
     "vite-plugin-wasm": "^3.2.2"
   },

--- a/app/src/components/codeExportModal/index.tsx
+++ b/app/src/components/codeExportModal/index.tsx
@@ -5,8 +5,8 @@ import json from "react-syntax-highlighter/dist/esm/languages/hljs/json";
 import py from "react-syntax-highlighter/dist/esm/languages/hljs/python";
 import atomOneLight from "react-syntax-highlighter/dist/esm/styles/hljs/atom-one-light";
 import atomOneDark from "react-syntax-highlighter/dist/esm/styles/hljs/atom-one-dark";
-import type { VizSpecStore } from '@kanaries/graphic-walker/dist/store/visualSpecStore'
-import { IChart } from "@kanaries/graphic-walker/dist/interfaces";
+import type { VizSpecStore } from '@kanaries/graphic-walker/store/visualSpecStore'
+import type { IChart } from "@kanaries/graphic-walker/interfaces";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import commonStore from "@/store/common";
 import { darkModeContext } from "@/store/context";

--- a/app/src/components/codeExportModal/usePythonCode.ts
+++ b/app/src/components/codeExportModal/usePythonCode.ts
@@ -1,5 +1,5 @@
-import { chartToWorkflow } from "@kanaries/graphic-walker";
-import { IChart } from "@kanaries/graphic-walker/dist/interfaces";
+import { chartToWorkflow } from "@kanaries/graphic-walker/utils/workflow";
+import type { IChart } from "@kanaries/graphic-walker/interfaces";
 import { useMemo } from "react"
 
 export function usePythonCode (props: {

--- a/app/src/components/preview/index.tsx
+++ b/app/src/components/preview/index.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { observer } from "mobx-react-lite";
 import pako from "pako";
 import { PureRenderer } from '@kanaries/graphic-walker';
-import type { IDarkMode, IThemeKey } from '@kanaries/graphic-walker/dist/interfaces';
+import type { IDarkMode, IThemeKey } from '@kanaries/graphic-walker/interfaces';
 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 // @ts-ignore

--- a/app/src/components/uploadChartModal/index.tsx
+++ b/app/src/components/uploadChartModal/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { observer } from "mobx-react-lite";
-import type { IGWHandler } from "@kanaries/graphic-walker/dist/interfaces";
-import type { VizSpecStore } from '@kanaries/graphic-walker/dist/store/visualSpecStore'
+import type { IGWHandler } from "@kanaries/graphic-walker/interfaces";
+import type { VizSpecStore } from '@kanaries/graphic-walker/store/visualSpecStore'
 import { chartToWorkflow } from "@kanaries/graphic-walker"
 
 import communicationStore from "../../store/communication";

--- a/app/src/dataSource/index.ts
+++ b/app/src/dataSource/index.ts
@@ -1,5 +1,5 @@
 import type { IDataSourceProps } from "../interfaces";
-import type { IRow, IDataQueryPayload } from "@kanaries/graphic-walker/dist/interfaces";
+import type { IRow, IDataQueryPayload } from "@kanaries/graphic-walker/interfaces";
 import commonStore from "../store/common";
 import communicationStore from "../store/communication"
 import { parser_dsl_with_meta } from "@kanaries/gw-dsl-parser";

--- a/app/src/index.tsx
+++ b/app/src/index.tsx
@@ -2,8 +2,8 @@ import React, { useContext, useEffect, useState } from 'react';
 import ReactDOM from 'react-dom';
 import { observer } from "mobx-react-lite";
 import { GraphicWalker, PureRenderer, GraphicRenderer, TableWalker } from '@kanaries/graphic-walker'
-import type { VizSpecStore } from '@kanaries/graphic-walker/dist/store/visualSpecStore'
-import { IRow, IGWHandler, IViewField, ISegmentKey, IDarkMode } from '@kanaries/graphic-walker/dist/interfaces';
+import type { VizSpecStore } from '@kanaries/graphic-walker/store/visualSpecStore'
+import type { IRow, IGWHandler, IViewField, ISegmentKey, IDarkMode } from '@kanaries/graphic-walker/interfaces';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 import Options from './components/options';

--- a/app/src/interfaces/index.ts
+++ b/app/src/interfaces/index.ts
@@ -1,5 +1,5 @@
-import type { IRow, IMutField } from '@kanaries/graphic-walker/dist/interfaces'
-import type { IDarkMode, IThemeKey, IComputationFunction } from '@kanaries/graphic-walker/dist/interfaces';
+import type { IRow, IMutField } from '@kanaries/graphic-walker/interfaces'
+import type { IDarkMode, IThemeKey, IComputationFunction } from '@kanaries/graphic-walker/interfaces';
 
 export interface IAppProps {
     // graphic-walker props

--- a/app/src/lib/dslToWorkflow.ts
+++ b/app/src/lib/dslToWorkflow.ts
@@ -1,4 +1,4 @@
-import { chartToWorkflow } from '@kanaries/graphic-walker/src/utils/workflow';
+import { chartToWorkflow } from "@kanaries/graphic-walker/utils/workflow";
 
 export default function Transform(str: string) {
     return JSON.stringify(chartToWorkflow(JSON.parse(str)));

--- a/app/src/lib/vegaToDsl.ts
+++ b/app/src/lib/vegaToDsl.ts
@@ -1,4 +1,4 @@
-import { VegaliteMapper } from '@kanaries/graphic-walker/src/lib/vl2gw';
+import { VegaliteMapper } from '@kanaries/graphic-walker/lib/vl2gw';
 
 export default function Transform(str: string) {
     const params = JSON.parse(str);

--- a/app/src/tools/exportDataframe.tsx
+++ b/app/src/tools/exportDataframe.tsx
@@ -7,8 +7,8 @@ import { Loader2 } from "lucide-react"
 
 import type { IAppProps } from '../interfaces';
 import { parser_dsl_with_meta } from "@kanaries/gw-dsl-parser";
-import type { ToolbarButtonItem } from "@kanaries/graphic-walker/dist/components/toolbar/toolbar-button"
-import type { VizSpecStore } from '@kanaries/graphic-walker/dist/store/visualSpecStore'
+import type { ToolbarButtonItem } from "@kanaries/graphic-walker/components/toolbar/toolbar-button"
+import type { VizSpecStore } from '@kanaries/graphic-walker/store/visualSpecStore'
 
 export function getExportDataframeTool(
     props: IAppProps,

--- a/app/src/tools/exportTool.tsx
+++ b/app/src/tools/exportTool.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { CodeBracketSquareIcon } from '@heroicons/react/24/outline';
 
-import type { ToolbarButtonItem } from "@kanaries/graphic-walker/dist/components/toolbar/toolbar-button"
+import type { ToolbarButtonItem } from "@kanaries/graphic-walker/components/toolbar/toolbar-button"
 
 
 export function getExportTool(

--- a/app/src/tools/loginTool.tsx
+++ b/app/src/tools/loginTool.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { UserIcon } from '@heroicons/react/24/outline';
 
-import type { ToolbarButtonItem } from "@kanaries/graphic-walker/dist/components/toolbar/toolbar-button"
+import type { ToolbarButtonItem } from "@kanaries/graphic-walker/components/toolbar/toolbar-button"
 
 
 export function getLoginTool(

--- a/app/src/tools/saveTool.tsx
+++ b/app/src/tools/saveTool.tsx
@@ -9,9 +9,9 @@ import { DocumentTextIcon } from '@heroicons/react/24/outline';
 import { Loader2 } from "lucide-react"
 
 import type { IAppProps } from '../interfaces';
-import type { IGWHandler } from '@kanaries/graphic-walker/dist/interfaces';
-import type { ToolbarButtonItem } from "@kanaries/graphic-walker/dist/components/toolbar/toolbar-button"
-import type { VizSpecStore } from '@kanaries/graphic-walker/dist/store/visualSpecStore'
+import type { IGWHandler } from '@kanaries/graphic-walker/interfaces';
+import type { ToolbarButtonItem } from "@kanaries/graphic-walker/components/toolbar/toolbar-button"
+import type { VizSpecStore } from '@kanaries/graphic-walker/store/visualSpecStore'
 
 function saveJupyterNotebook() {
     const rootDocument = window.parent.document;

--- a/app/src/tools/uploadChartTool.tsx
+++ b/app/src/tools/uploadChartTool.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { ArrowUpCircleIcon } from '@heroicons/react/24/outline';
 
-import type { ToolbarButtonItem } from "@kanaries/graphic-walker/dist/components/toolbar/toolbar-button"
+import type { ToolbarButtonItem } from "@kanaries/graphic-walker/components/toolbar/toolbar-button"
 
 export function getUploadChartTool(
     setUploadChartModalOpen: React.Dispatch<React.SetStateAction<boolean>>

--- a/app/src/utils/formatSpec.ts
+++ b/app/src/utils/formatSpec.ts
@@ -1,4 +1,4 @@
-import { VegaliteMapper } from '@kanaries/graphic-walker/src/lib/vl2gw';
+import { VegaliteMapper } from '@kanaries/graphic-walker/lib/vl2gw';
 
 export default function FormatSpec(spec: any[], fields: any[]) {
     return spec.map((item, index) => {

--- a/app/src/utils/save.ts
+++ b/app/src/utils/save.ts
@@ -1,5 +1,5 @@
 import * as htmlToImage from 'html-to-image';
-import type { IChartExportResult } from '@kanaries/graphic-walker/dist/interfaces';
+import type { IChartExportResult } from '@kanaries/graphic-walker/interfaces';
 
 export function download(data: string, filename: string, type: string) {
     var file = new Blob([data], { type: type });

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -11,7 +11,7 @@
       "downlevelIteration": true,
       "noImplicitAny": false,
       "module": "ESNext",
-      "moduleResolution": "Node",
+      "moduleResolution": "Bundler",
       "resolveJsonModule": true,
       "isolatedModules": true,
       "noEmit": true,

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -1045,10 +1045,10 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
-"@kanaries/graphic-walker@0.4.55":
-  version "0.4.55"
-  resolved "https://registry.yarnpkg.com/@kanaries/graphic-walker/-/graphic-walker-0.4.55.tgz#da8edb407ff34b1d07427be01237b5a329a81647"
-  integrity sha512-nnkzcuBY4gLPYlgsvkHXseLqiGr1W45bVm3r9SMEzMTHhyezxAk0fH5Ham5ToPT+qCo5NAjJgOTsSBWsHV7VXg==
+"@kanaries/graphic-walker@0.4.56":
+  version "0.4.56"
+  resolved "https://registry.yarnpkg.com/@kanaries/graphic-walker/-/graphic-walker-0.4.56.tgz#fb277b21b6fdcca41ec99728accbcaf46566f95d"
+  integrity sha512-8KcWvhkDzVu9S6tWFSiz5qcYRsZDRPpUsFU5Wgmechk3v57ymJUC3RnJDFLv3sOs8IqwN+BXa9/I4FWht48WEQ==
   dependencies:
     "@headlessui-float/react" "^0.11.4"
     "@headlessui/react" "1.7.12"
@@ -1056,6 +1056,7 @@
     "@kanaries/react-beautiful-dnd" "^0.1.1"
     "@kanaries/web-data-loader" "^0.1.7"
     "@radix-ui/react-checkbox" "^1.0.4"
+    "@radix-ui/react-collapsible" "^1.0.3"
     "@radix-ui/react-context-menu" "^2.1.5"
     "@radix-ui/react-dialog" "^1.0.5"
     "@radix-ui/react-dropdown-menu" "^2.0.6"
@@ -1206,6 +1207,21 @@
     "@radix-ui/react-use-controllable-state" "1.0.1"
     "@radix-ui/react-use-previous" "1.0.1"
     "@radix-ui/react-use-size" "1.0.1"
+
+"@radix-ui/react-collapsible@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-collapsible/-/react-collapsible-1.0.3.tgz#df0e22e7a025439f13f62d4e4a9e92c4a0df5b81"
+  integrity sha512-UBmVDkmR6IvDsloHVN+3rtx4Mi5TFvylYXpluuv0f37dtaz3H99bp8No0LGXRigVpl3UAT4l9j6bIchh42S/Gg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.1"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-context" "1.0.1"
+    "@radix-ui/react-id" "1.0.1"
+    "@radix-ui/react-presence" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-use-controllable-state" "1.0.1"
+    "@radix-ui/react-use-layout-effect" "1.0.1"
 
 "@radix-ui/react-collection@1.0.3":
   version "1.0.3"
@@ -5280,10 +5296,10 @@ type-fest@^0.21.3:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
   integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
 
-typescript@^4.9.5:
-  version "4.9.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
-  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+typescript@^5.4.2:
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.2.tgz#0ae9cebcfae970718474fe0da2c090cad6577372"
+  integrity sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==
 
 update-browserslist-db@^1.0.10:
   version "1.0.11"


### PR DESCRIPTION
This PR updates graphic walker to 0.4.56 to resolve issue about datetime apperence and background of downloaded image of charts.