### PR TITLE
fix: StrictVersion was removed in python3.12

### DIFF
--- a/pygwalker/__init__.py
+++ b/pygwalker/__init__.py
@@ -10,7 +10,7 @@ from pygwalker.utils.execute_env_check import check_kaggle as __check_kaggle
 from pygwalker.services.global_var import GlobalVarManager
 from pygwalker.services.kaggle import show_tips_user_kaggle as __show_tips_user_kaggle
 
-__version__ = "0.4.8a4"
+__version__ = "0.4.8a5"
 __hash__ = __rand_str()
 
 from pygwalker.api.jupyter import walk, render, table

--- a/pygwalker/api/streamlit.py
+++ b/pygwalker/api/streamlit.py
@@ -1,5 +1,5 @@
 from typing import Union, Dict, Optional, TYPE_CHECKING, List, Any
-from distutils.version import StrictVersion
+from packaging.version import Version
 from copy import deepcopy
 import json
 
@@ -221,7 +221,7 @@ class StreamlitRenderer:
         """
         cur_spec_obj = deepcopy(self.walker.vis_spec[index])
 
-        if StrictVersion(self.walker.spec_version) > StrictVersion("0.3.11"):
+        if Version(self.walker.spec_version) > Version("0.3.11"):
             chart_size_config = cur_spec_obj["layout"]["size"]
         else:
             chart_size_config = cur_spec_obj["config"]["size"]

--- a/pygwalker/services/spec.py
+++ b/pygwalker/services/spec.py
@@ -1,6 +1,6 @@
 from urllib import request
 from typing import Tuple, Dict, Any, List, Union
-from distutils.version import StrictVersion
+from packaging.version import Version
 from copy import deepcopy
 import json
 import os
@@ -183,13 +183,13 @@ def get_spec_json(spec: Union[str, List[Any], Dict[str, Any]]) -> Tuple[Dict[str
     if isinstance(spec_obj, dict) and not _is_pygwalker_config(spec_obj):
         return {"chart_map": {}, "config": [spec_obj], "workflow_list": []}, "vega_single"
 
-    if StrictVersion(spec_obj.get("version", "0.1.0")) <= StrictVersion("0.3.17a4"):
+    if Version(spec_obj.get("version", "0.1.0")) <= Version("0.3.17a4"):
         spec_obj["config"] = _config_adapter(spec_obj["config"])
 
     if isinstance(spec_obj["config"], str):
         spec_obj["config"] = json.loads(spec_obj["config"])
 
-    if StrictVersion(spec_obj.get("version", "0.1.0")) <= StrictVersion("0.4.7a5"):
+    if Version(spec_obj.get("version", "0.1.0")) <= Version("0.4.7a5"):
         spec_obj["config"] = _config_adapter_045a5(spec_obj["config"])
 
     return spec_obj, spec_type

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "pytz",
     "kanaries_track==0.0.4",
     "cachetools",
+    "packaging",
 ]
 [project.urls]
 homepage = "https://github.com/Kanaries/pygwalker"


### PR DESCRIPTION
related issue: #493 