### PR TITLE
fix: viewer container size base on the root iframe in streamlit

### DIFF
--- a/app/src/index.tsx
+++ b/app/src/index.tsx
@@ -397,9 +397,13 @@ function ChartPreviewApp(props: IChartPreviewProps, id: string) {
 
 function GraphicRendererApp(props: IAppProps) {
     const computationCallback = getComputationCallback(props);
+    const containerSize = props["containerSize"] ?? [null, null];
     const globalProps = {
         rawFields: props.rawFields,
-        containerStyle: { height: "700px", width: "60%" },
+        containerStyle: {
+            height: containerSize[1] ? `${containerSize[1]-200}px` : "700px",
+            width: containerSize[0] ? `${containerSize[0]-20}px` : "60%"
+        },
         themeKey:props.themeKey,
         dark: useContext(darkModeContext),
     }

--- a/pygwalker/api/streamlit.py
+++ b/pygwalker/api/streamlit.py
@@ -191,7 +191,7 @@ class StreamlitRenderer:
         scrolling: bool = False,
     ) -> "DeltaGenerator":
         """Render filter renderer UI"""
-        html = self._get_html(mode="filter_renderer")
+        html = self._get_html(mode="filter_renderer", **{"containerSize": [width, height]})
         return components.html(html, height=height, width=width, scrolling=scrolling)
 
     @deprecated("render_filter_renderer is deprecated, use viewer instead.")


### PR DESCRIPTION
This is just a temporary solution.

Pygwalker is testing the component rendering method recommended by streamlit, which will not require users to specify additional width, height, and scrolling, about detail: https://github.com/Kanaries/pygwalker/issues/531

