### PR TITLE
feat: update graphic-walker version

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@headlessui/react": "^1.7.14",
     "@heroicons/react": "^2.0.8",
-    "@kanaries/graphic-walker": "0.4.62",
+    "@kanaries/graphic-walker": "0.4.63",
     "@kanaries/gw-dsl-parser": "0.1.47",
     "@radix-ui/react-checkbox": "^1.0.4",
     "@radix-ui/react-dialog": "^1.0.5",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -1045,10 +1045,10 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
-"@kanaries/graphic-walker@0.4.62":
-  version "0.4.62"
-  resolved "https://registry.yarnpkg.com/@kanaries/graphic-walker/-/graphic-walker-0.4.62.tgz#59f6b4fbf2913ab3416a5334692f5f2f93e81f8e"
-  integrity sha512-fQCR3Eqxf3An1DH/g8q+ZsEV8ewtcD0G48IBD1eu2+HxR+F0qd/Sa4zcIQD9b7Aa9WCX8G7tyRYeSD64ZOFhMQ==
+"@kanaries/graphic-walker@0.4.63":
+  version "0.4.63"
+  resolved "https://registry.yarnpkg.com/@kanaries/graphic-walker/-/graphic-walker-0.4.63.tgz#2ab7d655f5530f1aeec0ec934e144a7129a5badb"
+  integrity sha512-GqailsQBkRFSr14ZjNn447ZbE7CmNVvMCMcYy21xmmfH8yW16TtVtht649zDRsBtmkp4X4s2he5SMEf++HLgPw==
   dependencies:
     "@headlessui-float/react" "^0.11.4"
     "@headlessui/react" "1.7.12"

--- a/pygwalker/__init__.py
+++ b/pygwalker/__init__.py
@@ -10,7 +10,7 @@ from pygwalker.utils.execute_env_check import check_kaggle as __check_kaggle
 from pygwalker.services.global_var import GlobalVarManager
 from pygwalker.services.kaggle import show_tips_user_kaggle as __show_tips_user_kaggle
 
-__version__ = "0.4.9a0"
+__version__ = "0.4.8.1"
 __hash__ = __rand_str()
 
 from pygwalker.api.jupyter import walk, render, table


### PR DESCRIPTION
Starting from this version, some urgent bug fixes will be released with smaller version numbers.

For example, If you are using the "0.4.8" version, the "0.4.8.xxx" version update prompt will not appear in the UI.

Pre-release versions will be updated using another branch "pre-release".