### PR TITLE
fix: "Copy to Clipboard" in different browser

### DIFF
--- a/app/src/components/codeExportModal/index.tsx
+++ b/app/src/components/codeExportModal/index.tsx
@@ -42,35 +42,10 @@ const CodeExport: React.FC<ICodeExport> = observer((props) => {
     }, [setOpen]);
 
     const copyToCliboard = async (content: string) => {
-        const isChromium = () => {
-            const optionalChrome = (window as any).chrome;
-            const isChromiumWithExtension = optionalChrome && optionalChrome.runtime;
-            const isChromiumWithoutExtension = optionalChrome && "webstore" in optionalChrome;
-            const isUserAgentChromium = !!navigator.userAgent.match(/Chrom(e|ium)\/[\d\.]+/);
-            return isUserAgentChromium && (isChromiumWithExtension || isChromiumWithoutExtension);
-        };
-
-        // for Firefox and Webkit browser
-        if (!isChromium()) {
-            try {
-                navigator.clipboard.writeText(content);
-                setOpen(false);
-            } catch(e) {
-                setTips("Clipboard write failed. Please copy manully.");
-            }
-            return;
-        }
-
-        const queryOpts = { name: "clipboard-read" as PermissionName, allowWithoutGesture: false };
-        const permissionStatus = await navigator.permissions.query(queryOpts);
         try {
-            if (permissionStatus.state !== "denied") {
-                navigator.clipboard.writeText(content);
-                setOpen(false);
-            } else {
-                setTips("The Clipboard API has been blocked in this environment. Please copy manully.");
-            }
-        } catch (e) {
+            navigator.clipboard.writeText(content);
+            setOpen(false);
+        } catch(e) {
             setTips("The Clipboard API has been blocked in this environment. Please copy manully.");
         }
     };

--- a/app/src/components/codeExportModal/index.tsx
+++ b/app/src/components/codeExportModal/index.tsx
@@ -5,7 +5,7 @@ import json from "react-syntax-highlighter/dist/esm/languages/hljs/json";
 import py from "react-syntax-highlighter/dist/esm/languages/hljs/python";
 import atomOneLight from "react-syntax-highlighter/dist/esm/styles/hljs/atom-one-light";
 import atomOneDark from "react-syntax-highlighter/dist/esm/styles/hljs/atom-one-dark";
-import type { VizSpecStore } from '@kanaries/graphic-walker/store/visualSpecStore'
+import type { VizSpecStore } from "@kanaries/graphic-walker/store/visualSpecStore";
 import type { IChart } from "@kanaries/graphic-walker/interfaces";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import commonStore from "@/store/common";
@@ -42,6 +42,25 @@ const CodeExport: React.FC<ICodeExport> = observer((props) => {
     }, [setOpen]);
 
     const copyToCliboard = async (content: string) => {
+        const isChromium = () => {
+            const optionalChrome = (window as any).chrome;
+            const isChromiumWithExtension = optionalChrome && optionalChrome.runtime;
+            const isChromiumWithoutExtension = optionalChrome && "webstore" in optionalChrome;
+            const isUserAgentChromium = !!navigator.userAgent.match(/Chrom(e|ium)\/[\d\.]+/);
+            return isUserAgentChromium && (isChromiumWithExtension || isChromiumWithoutExtension);
+        };
+
+        // for Firefox and Webkit browser
+        if (!isChromium()) {
+            try {
+                navigator.clipboard.writeText(content);
+                setOpen(false);
+            } catch(e) {
+                setTips("Clipboard write failed. Please copy manully.");
+            }
+            return;
+        }
+
         const queryOpts = { name: "clipboard-read" as PermissionName, allowWithoutGesture: false };
         const permissionStatus = await navigator.permissions.query(queryOpts);
         try {


### PR DESCRIPTION
As I reported in this issue #542 , the `Copy to Clipboard` in the Code Export dislog causes a JavaScript error. 
The reason of this error was also mentioned in this issue and what I did is just to check the browser the user uses. For the Chromium based browser, just copy as the original way while for the Firefox and Webkit browser, directly calls the `navigator.clipboard.writeText` function.