### PR TITLE
feat: add global param max_data_length

### DIFF
--- a/pygwalker/__init__.py
+++ b/pygwalker/__init__.py
@@ -10,7 +10,7 @@ from pygwalker.utils.execute_env_check import check_kaggle as __check_kaggle
 from pygwalker.services.global_var import GlobalVarManager
 from pygwalker.services.kaggle import show_tips_user_kaggle as __show_tips_user_kaggle
 
-__version__ = "0.4.8.3"
+__version__ = "0.4.8.4"
 __hash__ = __rand_str()
 
 from pygwalker.api.jupyter import walk, render, table

--- a/pygwalker/api/pygwalker.py
+++ b/pygwalker/api/pygwalker.py
@@ -42,8 +42,6 @@ from pygwalker._constants import JUPYTER_BYTE_LIMIT, JUPYTER_WIDGETS_BYTE_LIMIT
 from pygwalker.errors import DataCountLimitError
 from pygwalker import __version__
 
-RESPONSE_MAX_DATA_LENGTH = 1 * 1000 * 1000
-
 
 class PygWalker:
     """PygWalker"""
@@ -385,7 +383,7 @@ class PygWalker:
         def _get_datas(data: Dict[str, Any]):
             sql = data["sql"]
             datas = self.data_parser.get_datas_by_sql(sql)
-            if len(datas) > RESPONSE_MAX_DATA_LENGTH:
+            if len(datas) > GlobalVarManager.max_data_length:
                 raise DataCountLimitError()
             return {
                 "datas": datas
@@ -393,7 +391,7 @@ class PygWalker:
 
         def _get_datas_by_payload(data: Dict[str, Any]):
             datas = self.data_parser.get_datas_by_payload(data["payload"])
-            if len(datas) > RESPONSE_MAX_DATA_LENGTH:
+            if len(datas) > GlobalVarManager.max_data_length:
                 raise DataCountLimitError()
             return {
                 "datas": datas
@@ -402,7 +400,7 @@ class PygWalker:
         def _batch_get_datas_by_sql(data: Dict[str, Any]):
             result = self.data_parser.batch_get_datas_by_sql(data["queryList"])
             for datas in result:
-                if len(datas) > RESPONSE_MAX_DATA_LENGTH:
+                if len(datas) > GlobalVarManager.max_data_length:
                     raise DataCountLimitError()
             return {
                 "datas": result
@@ -411,7 +409,7 @@ class PygWalker:
         def _batch_get_datas_by_payload(data: Dict[str, Any]):
             result = self.data_parser.batch_get_datas_by_payload(data["queryList"])
             for datas in result:
-                if len(datas) > RESPONSE_MAX_DATA_LENGTH:
+                if len(datas) > GlobalVarManager.max_data_length:
                     raise DataCountLimitError()
             return {
                 "datas": result

--- a/pygwalker/services/global_var.py
+++ b/pygwalker/services/global_var.py
@@ -14,6 +14,7 @@ class GlobalVarManager:
     kanaries_api_host = "https://api.kanaries.net"
     kanaries_main_host = "https://kanaries.net"
     last_exported_dataframe = None
+    max_data_length = 1000 * 1000
 
     @classmethod
     def set_env(cls, env: Literal['Jupyter', 'Streamlit']):
@@ -42,3 +43,7 @@ class GlobalVarManager:
     @classmethod
     def set_last_exported_dataframe(cls, df: DataFrame):
         cls.last_exported_dataframe = df
+
+    @classmethod
+    def set_max_data_length(cls, length: int):
+        cls.max_data_length = length


### PR DESCRIPTION
related issue: https://github.com/Kanaries/pygwalker/issues/546

Users can customize the limit on the length of data items returned to the frontend from the python side.