### PR TITLE
bug fix to retrieve specs on URLs with path

### DIFF
--- a/app/src/utils/communication.tsx
+++ b/app/src/utils/communication.tsx
@@ -172,7 +172,7 @@ const initHttpCommunication = (gid: string, baseUrl: string) => {
     if (domain === "streamlit.app") {
         url = `/~/+/_stcore/_pygwalker/comm/${gid}`
     } else {
-        url = `/${baseUrl}/${gid}`
+        url = `${window.parent.document.href}/${baseUrl}/${gid}`
     }
 
     const sendMsg = async(action: string, data: any, timeout: number = 30_000) => {

--- a/app/src/utils/communication.tsx
+++ b/app/src/utils/communication.tsx
@@ -172,7 +172,7 @@ const initHttpCommunication = (gid: string, baseUrl: string) => {
     if (domain === "streamlit.app") {
         url = `/~/+/_stcore/_pygwalker/comm/${gid}`
     } else {
-        url = `${window.parent.document.href}/${baseUrl}/${gid}`
+        url = `${window.parent.document.href}${baseUrl}/${gid}`
     }
 
     const sendMsg = async(action: string, data: any, timeout: number = 30_000) => {

--- a/app/src/utils/communication.tsx
+++ b/app/src/utils/communication.tsx
@@ -172,7 +172,7 @@ const initHttpCommunication = (gid: string, baseUrl: string) => {
     if (domain === "streamlit.app") {
         url = `/~/+/_stcore/_pygwalker/comm/${gid}`
     } else {
-        url = `${window.parent.document.href}${baseUrl}/${gid}`
+        url = `${window.parent.document.location.href}${baseUrl}/${gid}`
     }
 
     const sendMsg = async(action: string, data: any, timeout: number = 30_000) => {


### PR DESCRIPTION
It looks like Pygwalker cannot read specs when the app's url is composed of a host + path. Writting seems fine though.
For example, I have an app deployed with the following URL structure:
ORIGIN/PATHNAME

This URL structure comes from corporate constraints within the company I work for.

I have taken a look at "pygwalkjer-app.iife.js", which I believe is generated by "communication.tsx", and I see this:
i=/${e}/${A}

I believe this should be updated to i=${window.parent.document.location.href}/${e}/${A}

To Reproduce
Steps to reproduce the behavior:

Deploy your Streamlit app with the following URL structure: i=/${e}/${A}
Use the following Python code
StreamlitRenderer(dataset=df, spec=PATH_TO_SPEC, spec_io_mode="rw")

Try load your Pygwalker chart
The page gets stuck on "Loading Graphic- Walker UI..."