### PR TITLE
fix: wrong api url when deployment custom proxy server

### DIFF
--- a/app/src/index.tsx
+++ b/app/src/index.tsx
@@ -312,7 +312,7 @@ const initOnJupyter = async(props: IAppProps) => {
 }
 
 const initOnHttpCommunication = async(props: IAppProps) => {
-    const comm = initHttpCommunication(props.id, props.communicationUrl);
+    const comm = await initHttpCommunication(props.id, props.communicationUrl);
     communicationStore.setComm(comm);
     if ((props.gwMode === "explore" || props.gwMode === "filter_renderer") && props.needLoadLastSpec) {
         const visSpecResp = await comm.sendMsg("get_latest_vis_spec", {});

--- a/pygwalker/__init__.py
+++ b/pygwalker/__init__.py
@@ -10,7 +10,7 @@ from pygwalker.utils.execute_env_check import check_kaggle as __check_kaggle
 from pygwalker.services.global_var import GlobalVarManager
 from pygwalker.services.kaggle import show_tips_user_kaggle as __show_tips_user_kaggle
 
-__version__ = "0.4.8.8"
+__version__ = "0.4.8.9a0"
 __hash__ = __rand_str()
 
 from pygwalker.api.jupyter import walk, render, table

--- a/pygwalker/api/pygwalker.py
+++ b/pygwalker/api/pygwalker.py
@@ -472,6 +472,7 @@ class PygWalker:
 
         comm.register("get_latest_vis_spec", get_latest_vis_spec)
         comm.register("request_data", reuqest_data_callback)
+        comm.register("ping", lambda _: {})
 
         if self.use_save_tool:
             comm.register("upload_spec_to_cloud", upload_spec_to_cloud)

--- a/pygwalker/communications/streamlit_comm.py
+++ b/pygwalker/communications/streamlit_comm.py
@@ -13,7 +13,7 @@ from .base import BaseCommunication
 streamlit_comm_map = {}
 
 _STREAMLIT_PREFIX_URL = config.get_option("server.baseUrlPath").strip("/")
-BASE_URL_PATH = (_STREAMLIT_PREFIX_URL + "/_stcore/_pygwalker/comm/").strip("/")
+BASE_URL_PATH = "/_stcore/_pygwalker/comm/".strip("/")
 PYGWALKER_API_PATH = make_url_path_regex(
     _STREAMLIT_PREFIX_URL,
     r"/_stcore/_pygwalker/comm/(.+)"


### PR DESCRIPTION
When the user deploys pygwalker + streamlit on a customized proxy service, the pygwalker api url cannot be requested normally. 

