### PR TITLE
feat: modify render preview

### DIFF
--- a/app/src/index.tsx
+++ b/app/src/index.tsx
@@ -22,7 +22,7 @@ import { Preview, ChartPreview } from './components/preview';
 import UploadSpecModal from "./components/uploadSpecModal"
 import UploadChartModal from './components/uploadChartModal';
 import InitModal from './components/initModal';
-import { getSaveTool, hidePreview } from './tools/saveTool';
+import { getSaveTool } from './tools/saveTool';
 import { getExportTool } from './tools/exportTool';
 import { getExportDataframeTool } from './tools/exportDataframe';
 import { formatExportedChartDatas } from "./utils/save";
@@ -64,7 +64,6 @@ const initChart = async (gwRef: React.MutableRefObject<IGWHandler | null>, total
                 curIndex: chart.index + 1,
                 total: chart.total,
             });
-            hidePreview(props.id);
         }
     }
     commonStore.setInitModalOpen(false);
@@ -308,7 +307,6 @@ const initOnJupyter = async(props: IAppProps) => {
         comm.sendMsgAsync("request_data", {}, null);
     }
     await initDslParser();
-    hidePreview(props.id);
 }
 
 const initOnHttpCommunication = async(props: IAppProps) => {
@@ -382,14 +380,19 @@ function GWalker(props: IAppProps, id: string) {
     })
 }
 
-function PreviewApp(props: IPreviewProps, id: string) {
+function PreviewApp(props: IPreviewProps, containerId: string) {
     props.charts = FormatSpec(props.charts.map(chart => chart.visSpec), [])
                     .map((visSpec, index) => { return {...props.charts[index], visSpec} });
+
+    if (window.document.getElementById(`gwalker-${props.gid}`)) {
+        window.document.getElementById(containerId)?.remove();
+    }
+
     ReactDOM.render(
         <MainApp darkMode={props.dark} hideToolBar>
             <Preview {...props} />
         </MainApp>,
-        document.getElementById(id)
+        document.getElementById(containerId)
     );
 }
 

--- a/app/src/tools/saveTool.tsx
+++ b/app/src/tools/saveTool.tsx
@@ -15,12 +15,6 @@ import type { IGWHandler } from '@kanaries/graphic-walker/interfaces';
 import type { ToolbarButtonItem } from "@kanaries/graphic-walker/components/toolbar/toolbar-button"
 import type { VizSpecStore } from '@kanaries/graphic-walker/store/visualSpecStore'
 
-function saveJupyterNotebook() {
-    const rootDocument = window.parent.document;
-    rootDocument.body.dispatchEvent(new KeyboardEvent('keydown', {key:'s', keyCode: 83, metaKey: true}));
-    rootDocument.body.dispatchEvent(new KeyboardEvent('keydown', {key:'s', keyCode: 83, ctrlKey: true}));
-}
-
 function DocumentTextIconWithRedPoint(iconProps) {
     return (
         <div style={{position: "relative"}} >
@@ -28,12 +22,6 @@ function DocumentTextIconWithRedPoint(iconProps) {
             <div style={{position: "absolute", top: "-2px", right: "-2px", width: "4px", height: "4px", borderRadius: "50%", backgroundColor: "red"}}></div>
         </div>
     )
-}
-
-export function hidePreview(id: string) {
-    setTimeout(() => {
-        window.parent.document.getElementById(`pygwalker-preview-${id}`)?.remove();
-    }, 500)
 }
 
 export function getSaveTool(
@@ -89,10 +77,8 @@ export function getSaveTool(
                 "chartData": await formatExportedChartDatas(chartData),
                 "workflowList": visSpec.map((spec) => chartToWorkflow(spec))
             });
-            saveJupyterNotebook();
         } finally {
             setSaving(false);
-            hidePreview(props.id);
         }
         
         if (["json_file", "json_ksf"].indexOf(props.specType) === -1) {

--- a/pygwalker/api/pygwalker.py
+++ b/pygwalker/api/pygwalker.py
@@ -254,7 +254,7 @@ class PygWalker:
 
         display_html(html_widgets)
         preview_tool.init_display()
-        preview_tool.render_gw_review(self._get_gw_preview_html())
+        preview_tool.async_render_gw_review(self._get_gw_preview_html())
 
     def display_preview_on_jupyter(self):
         """
@@ -356,7 +356,7 @@ class PygWalker:
             self.workflow_list = data.get("workflowList", [])
 
             if self.use_preview:
-                preview_tool.render_gw_review(self._get_gw_preview_html())
+                preview_tool.async_render_gw_review(self._get_gw_preview_html())
 
             save_chart_endpoint(data["chartData"])
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,8 @@ dependencies = [
     "kanaries_track==0.0.5",
     "cachetools",
     "packaging",
-    "numpy<2.0.0"
+    "numpy<2.0.0",
+    "ipylab<=1.0.0"
 ]
 [project.urls]
 homepage = "https://github.com/Kanaries/pygwalker"


### PR DESCRIPTION
Optimize preview rendering process.

Rendering previews blocks the main thread, while saving functionality and app initialization rely on main thread resources. When the Jupyter server needs to communicate over the public internet (such as with Kaggle), rendering the preview app, which requires downloading a 9MB HTML file, can slow down other functions.

