### PR TITLE
feat: add pygwalker web api tips in streamlit

### DIFF
--- a/pygwalker/__init__.py
+++ b/pygwalker/__init__.py
@@ -10,7 +10,7 @@ from pygwalker.utils.execute_env_check import check_kaggle as __check_kaggle
 from pygwalker.services.global_var import GlobalVarManager
 from pygwalker.services.kaggle import show_tips_user_kaggle as __show_tips_user_kaggle
 
-__version__ = "0.4.9"
+__version__ = "0.4.9.1"
 __hash__ = __rand_str()
 
 from pygwalker.api.jupyter import walk, render, table

--- a/pygwalker/errors.py
+++ b/pygwalker/errors.py
@@ -50,3 +50,12 @@ class DataCountLimitError(BaseError):
             "The query returned too many data entries, making it difficult for the frontend to render. Please adjust your chart configuration and try again.",
             code=ErrorCode.UNKNOWN_ERROR
         )
+
+
+class StreamlitPygwalkerApiError(BaseError):
+    """Raised when the config is invalid."""
+    def __init__(self) -> None:
+        super().__init__(
+            "Adding pygwalker web api to streamlit failed. If possible, please report this case to the pygwalker team. Thanks!",
+            code=ErrorCode.UNKNOWN_ERROR
+        )


### PR DESCRIPTION
In some special cases, it may not be possible to correctly inject pygwalker's route in tornado.