### PR TITLE
Updated the typo in polars_parser.py

### DIFF
--- a/pygwalker/data_parsers/polars_parser.py
+++ b/pygwalker/data_parsers/polars_parser.py
@@ -62,5 +62,5 @@ class PolarsDataFrameDataParser(BaseDataFrameDataParser[pl.DataFrame]):
         return "dimension"
 
     @property
-    def dataset_tpye(self) -> str:
+    def dataset_type(self) -> str:
         return "polars_dataframe"


### PR DESCRIPTION
The property dataset_tpye is misspelled. It should be dataset_type.

Fixed code snippet:

`@property
def dataset_type(self) -> str:
    return "polars_dataframe"
`