### PR TITLE
feat: support marimo poc version

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -15,6 +15,7 @@
     "serve": "vite preview"
   },
   "dependencies": {
+    "@anywidget/react": "^0.0.8",
     "@headlessui/react": "^1.7.14",
     "@heroicons/react": "^2.0.8",
     "@kanaries/graphic-walker": "0.4.70",

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -17,7 +17,7 @@ export default defineConfig((config: ConfigEnv) => {
         entry: path.resolve(__dirname, './src/index.tsx'),
         name: 'PyGWalkerApp',
         fileName: (format) => `pygwalker-app.${format}.js`,
-        formats: ['iife']
+        formats: ['iife', "es"]
       },
       minify: 'esbuild',
       sourcemap: false,
@@ -77,6 +77,8 @@ export default defineConfig((config: ConfigEnv) => {
       rollupOptions: {
         external: modulesNotToBundle,
         output: {
+          manualChunks: undefined,
+          inlineDynamicImports: true,
           globals: {
             'react': 'React',
             'react-dom': 'ReactDOM',

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -15,6 +15,18 @@
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
+"@anywidget/react@^0.0.8":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@anywidget/react/-/react-0.0.8.tgz#64b73cf9c9bad7bad180c8ba44134f09cc6eb44f"
+  integrity sha512-obr4EasXgWra485u+G4V3Msn7A1EOnowarvR62FRjpv2Rz6AyOoLMz2B03Z9j3DrWdD0634fMGu5ZAeRyjuV4w==
+  dependencies:
+    "@anywidget/types" "^0.2.0"
+
+"@anywidget/types@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@anywidget/types/-/types-0.2.0.tgz#6bae4e4fa36d193f565b0b78dc7eac50bb71beb4"
+  integrity sha512-+XtK4uwxRd4JpuevUMhirrbvC0V4yCA/i0lEjhmSAtOaxiXIg/vBKzaSonDuoZ1a9LEjUXTW2+m7w+ULgsJYvg==
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.22.13":
   version "7.22.13"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.22.13.tgz#e3c1c099402598483b7a8c46a721d1038803755e"

--- a/pygwalker/__init__.py
+++ b/pygwalker/__init__.py
@@ -10,7 +10,7 @@ from pygwalker.utils.execute_env_check import check_kaggle as __check_kaggle
 from pygwalker.services.global_var import GlobalVarManager
 from pygwalker.services.kaggle import show_tips_user_kaggle as __show_tips_user_kaggle
 
-__version__ = "0.4.9.10"
+__version__ = "0.4.9.11"
 __hash__ = __rand_str()
 
 from pygwalker.api.jupyter import walk, render, table

--- a/pygwalker/api/marimo.py
+++ b/pygwalker/api/marimo.py
@@ -1,0 +1,85 @@
+from typing import Union, List, Optional
+import inspect
+import json
+import pathlib
+
+from typing_extensions import Literal
+
+from .pygwalker import PygWalker
+from pygwalker.data_parsers.base import FieldSpec
+from pygwalker.data_parsers.database_parser import Connector
+from pygwalker._typing import DataFrame, IAppearance, IThemeKey
+from pygwalker.services.format_invoke_walk_code import get_formated_spec_params_code_from_frame
+from pygwalker.communications.anywidget_comm import AnywidgetCommunication
+import marimo as mo
+import anywidget
+import traitlets
+
+
+class _WalkerWidget(anywidget.AnyWidget):
+    """WalkerWidget"""
+    _esm = (pathlib.Path(__file__).parent.parent / "templates" / "dist" / "pygwalker-app.es.js").read_text()
+    props = traitlets.Unicode("").tag(sync=True)
+
+
+def walk(
+    dataset: Union[DataFrame, Connector, str],
+    gid: Union[int, str] = None,
+    *,
+    field_specs: Optional[List[FieldSpec]] = None,
+    theme_key: IThemeKey = 'g2',
+    appearance: IAppearance = 'media',
+    spec: str = "",
+    show_cloud_tool: bool = True,
+    kanaries_api_key: str = "",
+    default_tab: Literal["data", "vis"] = "vis",
+    **kwargs
+):
+    """Walk through pandas.DataFrame df with Graphic Walker
+
+    Args:
+        - dataset (pl.DataFrame | pd.DataFrame | Connector, optional): dataframe.
+        - gid (Union[int, str], optional): GraphicWalker container div's id ('gwalker-{gid}')
+
+    Kargs:
+        - field_specs (List[FieldSpec], optional): Specifications of some fields. They'll been automatically inferred from `df` if some fields are not specified.
+        - theme_key ('vega' | 'g2' | 'streamlit'): theme type.
+        - appearance (Literal['media' | 'light' | 'dark']): 'media': auto detect OS theme.
+        - spec (str): chart config data. config id, json, remote file url
+        - kanaries_api_key (str): kanaries api key, Default to "".
+        - default_tab (Literal["data", "vis"]): default tab to show. Default to "vis"
+    """
+    if field_specs is None:
+        field_specs = []
+
+    source_invoke_code = get_formated_spec_params_code_from_frame(
+        inspect.stack()[1].frame
+    )
+
+    widget = _WalkerWidget()
+    walker = PygWalker(
+        gid=gid,
+        dataset=dataset,
+        field_specs=field_specs,
+        spec=spec,
+        source_invoke_code=source_invoke_code,
+        theme_key=theme_key,
+        appearance=appearance,
+        show_cloud_tool=show_cloud_tool,
+        use_preview=False,
+        kernel_computation=True,
+        use_save_tool=True,
+        gw_mode="explore",
+        is_export_dataframe=True,
+        kanaries_api_key=kanaries_api_key,
+        default_tab=default_tab,
+        cloud_computation=False,
+        **kwargs
+    )
+    comm = AnywidgetCommunication(walker.gid)
+
+    widget.props = json.dumps(walker._get_props("marimo", []))
+    comm.register_widget(widget)
+    walker._init_callback(comm)
+
+    return mo.ui.anywidget(widget)

--- a/pygwalker/communications/anywidget_comm.py
+++ b/pygwalker/communications/anywidget_comm.py
@@ -1,0 +1,42 @@
+from typing import Any, Dict, Optional, List
+import uuid
+import json
+
+import anywidget
+
+from .base import BaseCommunication
+from pygwalker.utils.encode import DataFrameEncoder
+
+
+class AnywidgetCommunication(BaseCommunication):
+    """communication class for anywidget"""
+    def register_widget(self, widget: anywidget.AnyWidget) -> None:
+        """register widget"""
+        self.widget = widget
+        self.widget.on_msg(self._on_mesage)
+
+    def send_msg_async(self, action: str, data: Dict[str, Any], rid: Optional[str] = None):
+        """send message base on anywidget"""
+        if rid is None:
+            rid = uuid.uuid1().hex
+        msg = {
+            "gid": self.gid,
+            "rid": rid,
+            "action": action,
+            "data": data
+        }
+        self.widget.send({"type": "pyg_response", "data": json.dumps(msg, cls=DataFrameEncoder)})
+
+    def _on_mesage(self, _: anywidget.AnyWidget, data: Dict[str, Any], buffers: List[Any]):
+        if data.get("type", "") != "pyg_request":
+            return
+        
+        msg = data["msg"]
+        action = msg["action"]
+        rid = msg["rid"]
+
+        if action == "finish_request":
+            return
+
+        resp = self._receive_msg(action, msg["data"])
+        self.send_msg_async("finish_request", resp, rid)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,8 @@ dependencies = [
     "numpy<2.0.0",
     "ipylab<=1.0.0",
     "quickjs",
+    "traitlets",
+    "anywidget",
 ]
 [project.urls]
 homepage = "https://kanaries.net/pygwalker"


### PR DESCRIPTION
related issue:

https://github.com/Kanaries/pygwalker/issues/638

demo code:

```python
import pandas as pd
from pygwalker.api.marimo import walk

df = pd.read_csv("xxx.csv")

walk(df, spec="spec.json")
```

```python
import pandas as pd
import pygwalker.api.marimo as pyg

df = pd.read_csv("xxx.csv")
pyg.walk(df, spec="spec.json")
```

It can only make pygwalker work normally on Marimo, and currently no responsive features have been introduced.