### PR TITLE
feat: support common anywidget

### DIFF
--- a/app/src/index.tsx
+++ b/app/src/index.tsx
@@ -210,7 +210,7 @@ const ExploreApp: React.FC<IAppProps & {initChartFlag: boolean}> = (props) => {
     const exportTool = getExportTool(setExportOpen);
 
     const tools = [exportTool];
-    if (props.env && ["jupyter_widgets", "streamlit", "gradio", "marimo"].indexOf(props.env) !== -1 && props.useSaveTool) {
+    if (props.env && ["jupyter_widgets", "streamlit", "gradio", "marimo", "anywidget"].indexOf(props.env) !== -1 && props.useSaveTool) {
         const saveTool = getSaveTool(props, gwRef, storeRef, isChanged, setIsChanged);
         tools.push(saveTool);
     }

--- a/pygwalker/__init__.py
+++ b/pygwalker/__init__.py
@@ -10,7 +10,7 @@ from pygwalker.utils.execute_env_check import check_kaggle as __check_kaggle
 from pygwalker.services.global_var import GlobalVarManager
 from pygwalker.services.kaggle import show_tips_user_kaggle as __show_tips_user_kaggle
 
-__version__ = "0.4.9.12"
+__version__ = "0.4.9.13"
 __hash__ = __rand_str()
 
 from pygwalker.api.jupyter import walk, render, table

--- a/pygwalker/api/anywidget.py
+++ b/pygwalker/api/anywidget.py
@@ -11,7 +11,6 @@ from pygwalker.data_parsers.database_parser import Connector
 from pygwalker._typing import DataFrame, IAppearance, IThemeKey
 from pygwalker.services.format_invoke_walk_code import get_formated_spec_params_code_from_frame
 from pygwalker.communications.anywidget_comm import AnywidgetCommunication
-import marimo as mo
 import anywidget
 import traitlets
 
@@ -78,8 +77,8 @@ def walk(
     )
     comm = AnywidgetCommunication(walker.gid)
 
-    widget.props = json.dumps(walker._get_props("marimo", []))
+    widget.props = json.dumps(walker._get_props("anywidget", []))
     comm.register_widget(widget)
     walker._init_callback(comm)
 
-    return mo.ui.anywidget(widget)
+    return widget


### PR DESCRIPTION
support pure anywidget.

related issue: https://github.com/Kanaries/pygwalker/issues/650

example:

```python
import pandas as pd
from pygwalker.api.anywidget import walk

df = pd.read_csv("your_dataset_file.csv")
pyg_widget = walk(df)
```


panel example:

```python
import pandas as pd
from pygwalker.api.anywidget import walk

df = pd.read_csv("your_dataset_file.csv")
pyg_widget = walk(df)

pn.panel(pyg_widget, width=1500).servable()
```