### PR TITLE
Add marimo example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,31 @@
+# Examples
+This folder contains example implementations of Pygwalker across different interfaces.
+
+- [`component_demo.ipynb`](component_demo.ipynb): Creating various visualizations using Pygwalker's core components
+- [`dash_demo.py`](dash_demo.py): Integration of Pygwalker with Dash framework
+- [`gradio_demo.py`](gradio_demo.py): Using Pygwalker within Gradio applications
+- [`html_demo.py`](html_demo.py): Generating standalone HTML outputs with Pygwalker
+- [`jupyter_demo.ipynb`](jupyter_demo.ipynb): Basic Pygwalker usage in Jupyter environments
+- [`marimo_demo.py`](marimo_demo.py): Interactive data exploration using Pygwalker in Marimo notebooks
+- [`streamlit_demo.py`](streamlit_demo.py): Embedding Pygwalker visualizations in Streamlit apps
+- [`web_server_demo.py`](web_server_demo.py): Setting up Pygwalker with a web server
+
+> [!TIP]
+> To run the Marimo example, use:
+> ```shell
+> uvx marimo run --sandbox marimo_demo.py
+> ```
+> if you have [`uv`](https://docs.astral.sh/uv/) installed, or
+> ```shell
+> marimo run marimo_demo.py
+> ```
+> if you don't have uv installed (you'll need to manually install its dependencies; easier through the package manager sidebar option in marimo).
+> To edit the notebook source code, replace `run` with `edit` in the above commands.
+
+## Running examples
+Each example includes its own set of requirements and setup instructions within the file. Make sure you have Pygwalker installed:
+```shell
+pip install pygwalker
+```
+
+Additional dependencies may be required based on the specific interface you're using (e.g., streamlit, dash, gradio).

--- a/examples/marimo_demo.py
+++ b/examples/marimo_demo.py
@@ -1,0 +1,41 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "marimo",
+#     "pandas==2.2.3",
+#     "pygwalker==0.4.9.13",
+# ]
+# ///
+
+import marimo
+
+__generated_with = "0.9.15"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def __(pd, walk):
+    _df = pd.read_csv("https://kanaries-app.s3.ap-northeast-1.amazonaws.com/public-datasets/bike_sharing_dc.csv")
+    walk(_df)
+    return
+
+
+@app.cell
+def __(pd, pyg):
+    _df = pd.read_csv("https://kanaries-app.s3.ap-northeast-1.amazonaws.com/public-datasets/bike_sharing_dc.csv")
+    pyg.walk(_df)
+    return
+
+
+@app.cell
+def __():
+    # import libraries
+    import marimo as mo
+    import pandas as pd
+    from pygwalker.api.marimo import walk # Usage - directly use walk("<dataset-path>")
+    import pygwalker.api.marimo as pyg # Usage - directly use pyg.walk("<dataset-path>")
+    return mo, pd, pyg, walk
+
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
- Add marimo x Pygwalker demo code (reference to relevant issue comment - https://github.com/Kanaries/pygwalker/issues/638#issuecomment-2445667848)
- Add README for examples subfolder giving some context to running examples

I want to make some changes to the root README; including marimo in places where open in Google Colab and Kaggle links are provided. This will be a link to the marimo.cloud/marimo.new with a slug link; basically a marimo notebook running on the browser (made possible using [WASM ](https://marimo.io/blog/newsletter-2)+ Pyodide; relevant [marimo blog](https://marimo.io/blog/pyodide)) - will this be appreciated? Do let me know.

Also want to contribute to the docs usage for marimo here; like how it exists for jupyter (streamlit, gradio, etc.) - https://docs.kanaries.net/pygwalker/api-reference/jupyter