### PR TITLE
Add Kanaries Doc link to missing api key cloud error.

### DIFF
--- a/pygwalker/services/cloud_service.py
+++ b/pygwalker/services/cloud_service.py
@@ -67,7 +67,7 @@ class PrivateSession(requests.Session):
                 "If you are not kanaries user, please register it from 'https://kanaries.net/home/access' \n"
                 "Then refer 'https://github.com/Kanaries/pygwalker/wiki/How-to-get-api-key-of-kanaries%3F' to set kanaries_api_key. \n"
             ))
-            raise CloudFunctionError("no kanaries api key", code=ErrorCode.TOKEN_ERROR)
+            raise CloudFunctionError("no kanaries api key. visit: https://docs.kanaries.net/ for setup documentation.", code=ErrorCode.TOKEN_ERROR)
         resp = super().send(request, **kwargs)
         try:
             resp_json = resp.json()


### PR DESCRIPTION
Added Kanaries documentation link to cloud api key error for clarity.

![image](https://github.com/user-attachments/assets/3e61515b-2928-4cee-b17a-325a0a0df979)
