### PR TITLE
feat: add new init function for Connector

### DIFF
--- a/.github/workflows/auto-ci.yml
+++ b/.github/workflows/auto-ci.yml
@@ -88,6 +88,7 @@ jobs:
       - name: Try Pytest
         working-directory: ./
         run: |
+          pip install duckdb_engine
           pip install pytest
           pytest tests
       - name: Uploading notebooks


### PR DESCRIPTION
related issue: https://github.com/Kanaries/pygwalker/issues/688


```python
from sqlalchemy import create_engine
from pygwalker.data_parsers.database_parser import Connector

# sqlalchemy url
connector = Connector(database_url, view_sql)

# sqlalchemy engine
engine = create_engine(database_url)
connector = Connector.from_sqlalchemy_engine(engine, view_sql)

# sqlalchemy connection(adapt memory duckdb)
engine = create_engine(database_url)
with engine.connect() as conn:
    connector = Connector.from_sqlalchemy_connection(conn, view_sql)
```