### PR TITLE
Add Reflex optional dependency

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -18,3 +18,7 @@ pip install pygwalker
 ```
 
 Additional dependencies may be required based on the specific interface you're using (e.g., streamlit, dash, gradio).
+For the Reflex demo, install the optional Reflex plugin:
+```shell
+pip install "pygwalker[reflex]"
+```

--- a/examples/reflex_demo/reflex_demo.py
+++ b/examples/reflex_demo/reflex_demo.py
@@ -4,8 +4,8 @@ PyGWalker + Reflex integration demo.
 This demo shows how to integrate PyGWalker with Reflex, a Python web framework.
 
 To run this demo:
-1. Make sure you have installed PyGWalker and Reflex:
-   pip install pygwalker reflex
+1. Make sure you have installed PyGWalker with the Reflex plugin:
+   pip install "pygwalker[reflex]"
 
 2. Run the app:
    cd examples

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ repository = "https://github.com/Kanaries/pygwalker"
 pandas = ["pandas"]
 polars = ["polars"]
 streamlit = ["streamlit"]
+reflex = ["reflex"]
 notebook = [
     "jupyter-client<=7.4.9,>6.0.0",
     "jupyter-server<=2.5.0",
@@ -65,7 +66,7 @@ labv4 = [
     "ipywidgets>=8.0.0"
 ]
 all = [
-    "pygwalker[pandas,polars,streamlit]",
+    "pygwalker[pandas,polars,streamlit,reflex]",
 ]
 dev = [
     "build",


### PR DESCRIPTION
## Summary
- add `reflex` group in optional dependencies
- include Reflex in the `all` extra
- update examples to use `pip install "pygwalker[reflex]"`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68496455eb3483229590133bf2d6ec1d