### PR TITLE
fix: force duckdb wheel usage

### DIFF
--- a/.github/workflows/auto-ci.yml
+++ b/.github/workflows/auto-ci.yml
@@ -70,6 +70,8 @@ jobs:
           python ./scripts/test-init.py
       - name: Try Installing
         working-directory: ./
+        env:
+          PIP_ONLY_BINARY: "duckdb"
         run: |
           pip install ./
       - name: Try Install Modin In Linux Os

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "ipywidgets",
     "pydantic",
     "psutil",
-    "duckdb>=0.10.1,<2.0.0",
+    "duckdb>=0.10.4,<2.0.0",
     "pyarrow",
     "sqlglot>=23.15.8",
     "requests",


### PR DESCRIPTION
## Summary
- require duckdb 0.10.4+ so prebuilt wheels are available on newer interpreters
- force pip to install a prebuilt duckdb wheel during CI runs

## Testing
- pip install --disable-pip-version-check -e . *(fails: proxy blocking PyPI access)*

------
https://chatgpt.com/codex/tasks/task_e_690bdcc8e28c83228dab659b4b6ce563

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enforces prebuilt duckdb wheel usage in CI and raises minimum duckdb version to 0.10.4.
> 
> - **CI**:
>   - Set `PIP_ONLY_BINARY="duckdb"` in `.github/workflows/auto-ci.yml` to enforce wheel install during "Try Installing" step.
> - **Dependencies**:
>   - Bump `duckdb` requirement in `pyproject.toml` from `>=0.10.1` to `>=0.10.4` (still `<2.0.0`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ca198b4bb66257fcf529fbce2f7a61d7b348553. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->