### PR TITLE
Fix memory leak by replacing @lru_cache with instance-level caching in data parsers

### DIFF
--- a/pygwalker/data_parsers/cloud_dataset_parser.py
+++ b/pygwalker/data_parsers/cloud_dataset_parser.py
@@ -1,4 +1,5 @@
 from typing import Any, Dict, List, Optional
+from threading import Lock
 from decimal import Decimal
 import logging
 import io
@@ -32,6 +33,7 @@ class CloudDatasetParser(BaseDataParser):
         self.example_pandas_df = self._get_example_pandas_df()
         self._field_metas_cache = None
         self._raw_fields_cache = None
+        self._cache_lock = Lock()
 
     def _get_example_pandas_df(self) -> pd.DataFrame:
         datas = self._get_all_datas(1000)
@@ -43,26 +45,34 @@ class CloudDatasetParser(BaseDataParser):
 
     @property
     def field_metas(self) -> List[Dict[str, str]]:
-        if self._field_metas_cache is None:
-            data = self._get_all_datas(1)
-            self._field_metas_cache = get_data_meta_type(data[0]) if data else []
-        return self._field_metas_cache
+        cache = self._field_metas_cache
+        if cache is not None:
+            return cache
+        with self._cache_lock:
+            if self._field_metas_cache is None:
+                data = self._get_all_datas(1)
+                self._field_metas_cache = get_data_meta_type(data[0]) if data else []
+            return self._field_metas_cache
 
     @property
     def raw_fields(self) -> List[Dict[str, str]]:
-        if self._raw_fields_cache is None:
-            pandas_parser = PandasDataFrameDataParser(
-                self.example_pandas_df,
-                self.field_specs,
-                self.infer_string_to_date,
-                self.infer_number_to_dimension,
-                self.other_params
-            )
-            self._raw_fields_cache = [
-                {**field, "fid": field["name"]}
-                for field in pandas_parser.raw_fields
-            ]
-        return self._raw_fields_cache
+        cache = self._raw_fields_cache
+        if cache is not None:
+            return cache
+        with self._cache_lock:
+            if self._raw_fields_cache is None:
+                pandas_parser = PandasDataFrameDataParser(
+                    self.example_pandas_df,
+                    self.field_specs,
+                    self.infer_string_to_date,
+                    self.infer_number_to_dimension,
+                    self.other_params
+                )
+                self._raw_fields_cache = [
+                    {**field, "fid": field["name"]}
+                    for field in pandas_parser.raw_fields
+                ]
+            return self._raw_fields_cache
 
     def to_records(self, limit: Optional[int] = None) -> List[Dict[str, Any]]:
         if limit is None:


### PR DESCRIPTION
## Summary

Replace `@lru_cache` on instance methods with instance-level caching to fix memory leak. The global LRU cache keys by `self`, retaining parser instances and their DataFrames indefinitely.

## What's Changed

- **BaseDataFrameDataParser**: Add `_field_metas_cache`, `_raw_fields_cache`, `_cache_lock` for thread-safe instance-level caching with double-checked locking.
- **SparkDataFrameDataParser / DatabaseDataParser / CloudDatasetParser**: Apply the same pattern.
- Keep `@lru_cache` only for pure function `get_timezone_base_offset`.

## Behavior Compatibility

1. Public API unchanged (same properties and return structures).
2. Semantics preserved: once-per-instance computation, reuse for subsequent accesses.
3. `@lru_cache` automatically adds `cache_info()` and `cache_clear()` methods to decorated functions. This project does not use these methods internally, but **external code that explicitly calls them will raise `AttributeError` after this change** (e.g., `BaseDataFrameDataParser.field_metas.fget.cache_clear()`).

## Breaking Changes

None for normal usage. Only affects code introspecting or manipulating the LRU cache internals.

## Related Issues

Fixes #723 
