### PR TITLE
[codex] Fix data parser cache leaks with attribution

### DIFF
--- a/pygwalker/data_parsers/base.py
+++ b/pygwalker/data_parsers/base.py
@@ -141,19 +141,26 @@ class BaseDataFrameDataParser(Generic[DataFrame], BaseDataParser):
         self.infer_string_to_date = infer_string_to_date
         self.infer_number_to_dimension = infer_number_to_dimension
         self.other_params = other_params
+        self._field_metas_cache = None
+        self._raw_fields_cache = None
 
     @property
-    @lru_cache()
     def field_metas(self) -> List[Dict[str, str]]:
-        duckdb.register("pygwalker_mid_table", self._duckdb_df)
-        result = duckdb.query("SELECT * FROM pygwalker_mid_table LIMIT 1")
-        data = result.fetchone()
-        return get_data_meta_type(dict(zip(result.columns, data))) if data else []
+        if self._field_metas_cache is None:
+            duckdb.register("pygwalker_mid_table", self._duckdb_df)
+            result = duckdb.query("SELECT * FROM pygwalker_mid_table LIMIT 1")
+            data = result.fetchone()
+            self._field_metas_cache = get_data_meta_type(dict(zip(result.columns, data))) if data else []
+        return self._field_metas_cache
 
     @property
-    @lru_cache()
     def raw_fields(self) -> List[Dict[str, str]]:
-        return [self._infer_prop(col, self.field_specs) for _, col in enumerate(self._example_df.columns)]
+        if self._raw_fields_cache is None:
+            self._raw_fields_cache = [
+                self._infer_prop(col, self.field_specs)
+                for _, col in enumerate(self._example_df.columns)
+            ]
+        return self._raw_fields_cache
 
     def _infer_prop(self, col: str, field_specs: List[FieldSpec] = None) -> Dict[str, str]:
         """get IMutField

--- a/pygwalker/data_parsers/base.py
+++ b/pygwalker/data_parsers/base.py
@@ -1,6 +1,7 @@
 from typing import Generic, Dict, List, Any, Optional
 from typing_extensions import Literal
 from functools import lru_cache
+from threading import Lock
 from datetime import datetime, date
 from datetime import timedelta
 import abc
@@ -143,24 +144,33 @@ class BaseDataFrameDataParser(Generic[DataFrame], BaseDataParser):
         self.other_params = other_params
         self._field_metas_cache = None
         self._raw_fields_cache = None
+        self._cache_lock = Lock()
 
     @property
     def field_metas(self) -> List[Dict[str, str]]:
-        if self._field_metas_cache is None:
-            duckdb.register("pygwalker_mid_table", self._duckdb_df)
-            result = duckdb.query("SELECT * FROM pygwalker_mid_table LIMIT 1")
-            data = result.fetchone()
-            self._field_metas_cache = get_data_meta_type(dict(zip(result.columns, data))) if data else []
-        return self._field_metas_cache
+        cache = self._field_metas_cache
+        if cache is not None:
+            return cache
+        with self._cache_lock:
+            if self._field_metas_cache is None:
+                duckdb.register("pygwalker_mid_table", self._duckdb_df)
+                result = duckdb.query("SELECT * FROM pygwalker_mid_table LIMIT 1")
+                data = result.fetchone()
+                self._field_metas_cache = get_data_meta_type(dict(zip(result.columns, data))) if data else []
+            return self._field_metas_cache
 
     @property
     def raw_fields(self) -> List[Dict[str, str]]:
-        if self._raw_fields_cache is None:
-            self._raw_fields_cache = [
-                self._infer_prop(col, self.field_specs)
-                for _, col in enumerate(self._example_df.columns)
-            ]
-        return self._raw_fields_cache
+        cache = self._raw_fields_cache
+        if cache is not None:
+            return cache
+        with self._cache_lock:
+            if self._raw_fields_cache is None:
+                self._raw_fields_cache = [
+                    self._infer_prop(col, self.field_specs)
+                    for _, col in enumerate(self._example_df.columns)
+                ]
+            return self._raw_fields_cache
 
     def _infer_prop(self, col: str, field_specs: List[FieldSpec] = None) -> Dict[str, str]:
         """get IMutField

--- a/pygwalker/data_parsers/base.py
+++ b/pygwalker/data_parsers/base.py
@@ -1,7 +1,6 @@
 from typing import Generic, Dict, List, Any, Optional
 from typing_extensions import Literal
-from functools import lru_cache
-from threading import Lock
+from functools import cached_property, lru_cache
 from datetime import datetime, date
 from datetime import timedelta
 import abc
@@ -142,35 +141,17 @@ class BaseDataFrameDataParser(Generic[DataFrame], BaseDataParser):
         self.infer_string_to_date = infer_string_to_date
         self.infer_number_to_dimension = infer_number_to_dimension
         self.other_params = other_params
-        self._field_metas_cache = None
-        self._raw_fields_cache = None
-        self._cache_lock = Lock()
 
-    @property
+    @cached_property
     def field_metas(self) -> List[Dict[str, str]]:
-        cache = self._field_metas_cache
-        if cache is not None:
-            return cache
-        with self._cache_lock:
-            if self._field_metas_cache is None:
-                duckdb.register("pygwalker_mid_table", self._duckdb_df)
-                result = duckdb.query("SELECT * FROM pygwalker_mid_table LIMIT 1")
-                data = result.fetchone()
-                self._field_metas_cache = get_data_meta_type(dict(zip(result.columns, data))) if data else []
-            return self._field_metas_cache
+        duckdb.register("pygwalker_mid_table", self._duckdb_df)
+        result = duckdb.query("SELECT * FROM pygwalker_mid_table LIMIT 1")
+        data = result.fetchone()
+        return get_data_meta_type(dict(zip(result.columns, data))) if data else []
 
-    @property
+    @cached_property
     def raw_fields(self) -> List[Dict[str, str]]:
-        cache = self._raw_fields_cache
-        if cache is not None:
-            return cache
-        with self._cache_lock:
-            if self._raw_fields_cache is None:
-                self._raw_fields_cache = [
-                    self._infer_prop(col, self.field_specs)
-                    for _, col in enumerate(self._example_df.columns)
-                ]
-            return self._raw_fields_cache
+        return [self._infer_prop(col, self.field_specs) for _, col in enumerate(self._example_df.columns)]
 
     def _infer_prop(self, col: str, field_specs: List[FieldSpec] = None) -> Dict[str, str]:
         """get IMutField

--- a/pygwalker/data_parsers/cloud_dataset_parser.py
+++ b/pygwalker/data_parsers/cloud_dataset_parser.py
@@ -1,5 +1,5 @@
 from typing import Any, Dict, List, Optional
-from threading import Lock
+from functools import cached_property
 from decimal import Decimal
 import logging
 import io
@@ -32,9 +32,6 @@ class CloudDatasetParser(BaseDataParser):
         self.other_params = other_params
         self._cloud_service = CloudService(other_params.get("kanaries_api_key", ""))
         self.example_pandas_df = self._get_example_pandas_df()
-        self._field_metas_cache = None
-        self._raw_fields_cache = None
-        self._cache_lock = Lock()
 
     def _get_example_pandas_df(self) -> pd.DataFrame:
         datas = self._get_all_datas(1000)
@@ -44,36 +41,21 @@ class CloudDatasetParser(BaseDataParser):
                 example_df[column] = example_df[column].astype(float)
         return example_df
 
-    @property
+    @cached_property
     def field_metas(self) -> List[Dict[str, str]]:
-        cache = self._field_metas_cache
-        if cache is not None:
-            return cache
-        with self._cache_lock:
-            if self._field_metas_cache is None:
-                data = self._get_all_datas(1)
-                self._field_metas_cache = get_data_meta_type(data[0]) if data else []
-            return self._field_metas_cache
+        data = self._get_all_datas(1)
+        return get_data_meta_type(data[0]) if data else []
 
-    @property
+    @cached_property
     def raw_fields(self) -> List[Dict[str, str]]:
-        cache = self._raw_fields_cache
-        if cache is not None:
-            return cache
-        with self._cache_lock:
-            if self._raw_fields_cache is None:
-                pandas_parser = PandasDataFrameDataParser(
-                    self.example_pandas_df,
-                    self.field_specs,
-                    self.infer_string_to_date,
-                    self.infer_number_to_dimension,
-                    self.other_params,
-                )
-                self._raw_fields_cache = [
-                    {**field, "fid": field["name"]}
-                    for field in pandas_parser.raw_fields
-                ]
-            return self._raw_fields_cache
+        pandas_parser = PandasDataFrameDataParser(
+            self.example_pandas_df,
+            self.field_specs,
+            self.infer_string_to_date,
+            self.infer_number_to_dimension,
+            self.other_params,
+        )
+        return [{**field, "fid": field["name"]} for field in pandas_parser.raw_fields]
 
     def to_records(self, limit: Optional[int] = None) -> List[Dict[str, Any]]:
         if limit is None:

--- a/pygwalker/data_parsers/cloud_dataset_parser.py
+++ b/pygwalker/data_parsers/cloud_dataset_parser.py
@@ -1,5 +1,4 @@
 from typing import Any, Dict, List, Optional
-from functools import lru_cache
 from decimal import Decimal
 import logging
 import io
@@ -32,6 +31,8 @@ class CloudDatasetParser(BaseDataParser):
         self.other_params = other_params
         self._cloud_service = CloudService(other_params.get("kanaries_api_key", ""))
         self.example_pandas_df = self._get_example_pandas_df()
+        self._field_metas_cache = None
+        self._raw_fields_cache = None
 
     def _get_example_pandas_df(self) -> pd.DataFrame:
         datas = self._get_all_datas(1000)
@@ -42,22 +43,27 @@ class CloudDatasetParser(BaseDataParser):
         return example_df
 
     @property
-    @lru_cache()
     def field_metas(self) -> List[Dict[str, str]]:
-        data = self._get_all_datas(1)
-        return get_data_meta_type(data[0]) if data else []
+        if self._field_metas_cache is None:
+            data = self._get_all_datas(1)
+            self._field_metas_cache = get_data_meta_type(data[0]) if data else []
+        return self._field_metas_cache
 
     @property
-    @lru_cache()
     def raw_fields(self) -> List[Dict[str, str]]:
-        pandas_parser = PandasDataFrameDataParser(
-            self.example_pandas_df,
-            self.field_specs,
-            self.infer_string_to_date,
-            self.infer_number_to_dimension,
-            self.other_params,
-        )
-        return [{**field, "fid": field["name"]} for field in pandas_parser.raw_fields]
+        if self._raw_fields_cache is None:
+            pandas_parser = PandasDataFrameDataParser(
+                self.example_pandas_df,
+                self.field_specs,
+                self.infer_string_to_date,
+                self.infer_number_to_dimension,
+                self.other_params,
+            )
+            self._raw_fields_cache = [
+                {**field, "fid": field["name"]}
+                for field in pandas_parser.raw_fields
+            ]
+        return self._raw_fields_cache
 
     def to_records(self, limit: Optional[int] = None) -> List[Dict[str, Any]]:
         if limit is None:

--- a/pygwalker/data_parsers/cloud_dataset_parser.py
+++ b/pygwalker/data_parsers/cloud_dataset_parser.py
@@ -1,4 +1,5 @@
 from typing import Any, Dict, List, Optional
+from threading import Lock
 from decimal import Decimal
 import logging
 import io
@@ -33,6 +34,7 @@ class CloudDatasetParser(BaseDataParser):
         self.example_pandas_df = self._get_example_pandas_df()
         self._field_metas_cache = None
         self._raw_fields_cache = None
+        self._cache_lock = Lock()
 
     def _get_example_pandas_df(self) -> pd.DataFrame:
         datas = self._get_all_datas(1000)
@@ -44,26 +46,34 @@ class CloudDatasetParser(BaseDataParser):
 
     @property
     def field_metas(self) -> List[Dict[str, str]]:
-        if self._field_metas_cache is None:
-            data = self._get_all_datas(1)
-            self._field_metas_cache = get_data_meta_type(data[0]) if data else []
-        return self._field_metas_cache
+        cache = self._field_metas_cache
+        if cache is not None:
+            return cache
+        with self._cache_lock:
+            if self._field_metas_cache is None:
+                data = self._get_all_datas(1)
+                self._field_metas_cache = get_data_meta_type(data[0]) if data else []
+            return self._field_metas_cache
 
     @property
     def raw_fields(self) -> List[Dict[str, str]]:
-        if self._raw_fields_cache is None:
-            pandas_parser = PandasDataFrameDataParser(
-                self.example_pandas_df,
-                self.field_specs,
-                self.infer_string_to_date,
-                self.infer_number_to_dimension,
-                self.other_params,
-            )
-            self._raw_fields_cache = [
-                {**field, "fid": field["name"]}
-                for field in pandas_parser.raw_fields
-            ]
-        return self._raw_fields_cache
+        cache = self._raw_fields_cache
+        if cache is not None:
+            return cache
+        with self._cache_lock:
+            if self._raw_fields_cache is None:
+                pandas_parser = PandasDataFrameDataParser(
+                    self.example_pandas_df,
+                    self.field_specs,
+                    self.infer_string_to_date,
+                    self.infer_number_to_dimension,
+                    self.other_params,
+                )
+                self._raw_fields_cache = [
+                    {**field, "fid": field["name"]}
+                    for field in pandas_parser.raw_fields
+                ]
+            return self._raw_fields_cache
 
     def to_records(self, limit: Optional[int] = None) -> List[Dict[str, Any]]:
         if limit is None:

--- a/pygwalker/data_parsers/database_parser.py
+++ b/pygwalker/data_parsers/database_parser.py
@@ -1,4 +1,5 @@
 from typing import Any, Dict, List, Optional
+from threading import Lock
 from decimal import Decimal
 import logging
 import json
@@ -152,6 +153,7 @@ class DatabaseDataParser(BaseDataParser):
         self.other_params = other_params
         self._field_metas_cache = None
         self._raw_fields_cache = None
+        self._cache_lock = Lock()
 
     def _get_example_pandas_df(self) -> pd.DataFrame:
         sql = self._format_sql(f"SELECT * FROM {self.placeholder_table_name} LIMIT 1000")
@@ -182,26 +184,34 @@ class DatabaseDataParser(BaseDataParser):
 
     @property
     def field_metas(self) -> List[Dict[str, str]]:
-        if self._field_metas_cache is None:
-            data = self._get_datas_by_sql(f"SELECT * FROM {self.placeholder_table_name} LIMIT 1")
-            self._field_metas_cache = get_data_meta_type(data[0]) if data else []
-        return self._field_metas_cache
+        cache = self._field_metas_cache
+        if cache is not None:
+            return cache
+        with self._cache_lock:
+            if self._field_metas_cache is None:
+                data = self._get_datas_by_sql(f"SELECT * FROM {self.placeholder_table_name} LIMIT 1")
+                self._field_metas_cache = get_data_meta_type(data[0]) if data else []
+            return self._field_metas_cache
 
     @property
     def raw_fields(self) -> List[Dict[str, str]]:
-        if self._raw_fields_cache is None:
-            pandas_parser = PandasDataFrameDataParser(
-                self.example_pandas_df,
-                self.field_specs,
-                self.infer_string_to_date,
-                self.infer_number_to_dimension,
-                self.other_params,
-            )
-            self._raw_fields_cache = [
-                {**field, "fid": field["name"]}
-                for field in pandas_parser.raw_fields
-            ]
-        return self._raw_fields_cache
+        cache = self._raw_fields_cache
+        if cache is not None:
+            return cache
+        with self._cache_lock:
+            if self._raw_fields_cache is None:
+                pandas_parser = PandasDataFrameDataParser(
+                    self.example_pandas_df,
+                    self.field_specs,
+                    self.infer_string_to_date,
+                    self.infer_number_to_dimension,
+                    self.other_params,
+                )
+                self._raw_fields_cache = [
+                    {**field, "fid": field["name"]}
+                    for field in pandas_parser.raw_fields
+                ]
+            return self._raw_fields_cache
 
     def to_records(self, limit: Optional[int] = None) -> List[Dict[str, Any]]:
         if limit is None:

--- a/pygwalker/data_parsers/database_parser.py
+++ b/pygwalker/data_parsers/database_parser.py
@@ -1,5 +1,4 @@
 from typing import Any, Dict, List, Optional
-from functools import lru_cache
 from decimal import Decimal
 import logging
 import json
@@ -151,6 +150,8 @@ class DatabaseDataParser(BaseDataParser):
         self.infer_string_to_date = infer_string_to_date
         self.infer_number_to_dimension = infer_number_to_dimension
         self.other_params = other_params
+        self._field_metas_cache = None
+        self._raw_fields_cache = None
 
     def _get_example_pandas_df(self) -> pd.DataFrame:
         sql = self._format_sql(f"SELECT * FROM {self.placeholder_table_name} LIMIT 1000")
@@ -180,22 +181,27 @@ class DatabaseDataParser(BaseDataParser):
         return "___pygwalker_temp_view_name___"
 
     @property
-    @lru_cache()
     def field_metas(self) -> List[Dict[str, str]]:
-        data = self._get_datas_by_sql(f"SELECT * FROM {self.placeholder_table_name} LIMIT 1")
-        return get_data_meta_type(data[0]) if data else []
+        if self._field_metas_cache is None:
+            data = self._get_datas_by_sql(f"SELECT * FROM {self.placeholder_table_name} LIMIT 1")
+            self._field_metas_cache = get_data_meta_type(data[0]) if data else []
+        return self._field_metas_cache
 
     @property
-    @lru_cache()
     def raw_fields(self) -> List[Dict[str, str]]:
-        pandas_parser = PandasDataFrameDataParser(
-            self.example_pandas_df,
-            self.field_specs,
-            self.infer_string_to_date,
-            self.infer_number_to_dimension,
-            self.other_params,
-        )
-        return [{**field, "fid": field["name"]} for field in pandas_parser.raw_fields]
+        if self._raw_fields_cache is None:
+            pandas_parser = PandasDataFrameDataParser(
+                self.example_pandas_df,
+                self.field_specs,
+                self.infer_string_to_date,
+                self.infer_number_to_dimension,
+                self.other_params,
+            )
+            self._raw_fields_cache = [
+                {**field, "fid": field["name"]}
+                for field in pandas_parser.raw_fields
+            ]
+        return self._raw_fields_cache
 
     def to_records(self, limit: Optional[int] = None) -> List[Dict[str, Any]]:
         if limit is None:

--- a/pygwalker/data_parsers/database_parser.py
+++ b/pygwalker/data_parsers/database_parser.py
@@ -1,5 +1,5 @@
 from typing import Any, Dict, List, Optional
-from threading import Lock
+from functools import cached_property
 from decimal import Decimal
 import logging
 import json
@@ -151,9 +151,6 @@ class DatabaseDataParser(BaseDataParser):
         self.infer_string_to_date = infer_string_to_date
         self.infer_number_to_dimension = infer_number_to_dimension
         self.other_params = other_params
-        self._field_metas_cache = None
-        self._raw_fields_cache = None
-        self._cache_lock = Lock()
 
     def _get_example_pandas_df(self) -> pd.DataFrame:
         sql = self._format_sql(f"SELECT * FROM {self.placeholder_table_name} LIMIT 1000")
@@ -182,36 +179,21 @@ class DatabaseDataParser(BaseDataParser):
     def placeholder_table_name(self) -> str:
         return "___pygwalker_temp_view_name___"
 
-    @property
+    @cached_property
     def field_metas(self) -> List[Dict[str, str]]:
-        cache = self._field_metas_cache
-        if cache is not None:
-            return cache
-        with self._cache_lock:
-            if self._field_metas_cache is None:
-                data = self._get_datas_by_sql(f"SELECT * FROM {self.placeholder_table_name} LIMIT 1")
-                self._field_metas_cache = get_data_meta_type(data[0]) if data else []
-            return self._field_metas_cache
+        data = self._get_datas_by_sql(f"SELECT * FROM {self.placeholder_table_name} LIMIT 1")
+        return get_data_meta_type(data[0]) if data else []
 
-    @property
+    @cached_property
     def raw_fields(self) -> List[Dict[str, str]]:
-        cache = self._raw_fields_cache
-        if cache is not None:
-            return cache
-        with self._cache_lock:
-            if self._raw_fields_cache is None:
-                pandas_parser = PandasDataFrameDataParser(
-                    self.example_pandas_df,
-                    self.field_specs,
-                    self.infer_string_to_date,
-                    self.infer_number_to_dimension,
-                    self.other_params,
-                )
-                self._raw_fields_cache = [
-                    {**field, "fid": field["name"]}
-                    for field in pandas_parser.raw_fields
-                ]
-            return self._raw_fields_cache
+        pandas_parser = PandasDataFrameDataParser(
+            self.example_pandas_df,
+            self.field_specs,
+            self.infer_string_to_date,
+            self.infer_number_to_dimension,
+            self.other_params,
+        )
+        return [{**field, "fid": field["name"]} for field in pandas_parser.raw_fields]
 
     def to_records(self, limit: Optional[int] = None) -> List[Dict[str, Any]]:
         if limit is None:

--- a/pygwalker/data_parsers/spark_parser.py
+++ b/pygwalker/data_parsers/spark_parser.py
@@ -1,5 +1,4 @@
 from typing import Any, Dict, List, Optional
-from functools import lru_cache
 import logging
 import io
 
@@ -40,24 +39,28 @@ class SparkDataFrameDataParser(BaseDataParser):
         self.infer_string_to_date = infer_string_to_date
         self.infer_number_to_dimension = infer_number_to_dimension
         self.other_params = other_params
+        self._field_metas_cache = None
+        self._raw_fields_cache = None
 
     @property
-    @lru_cache()
     def raw_fields(self) -> List[Dict[str, str]]:
-        pandas_parser = PandasDataFrameDataParser(
-            self.example_pandas_df,
-            self.field_specs,
-            self.infer_string_to_date,
-            self.infer_number_to_dimension,
-            self.other_params,
-        )
-        return pandas_parser.raw_fields
+        if self._raw_fields_cache is None:
+            pandas_parser = PandasDataFrameDataParser(
+                self.example_pandas_df,
+                self.field_specs,
+                self.infer_string_to_date,
+                self.infer_number_to_dimension,
+                self.other_params,
+            )
+            self._raw_fields_cache = pandas_parser.raw_fields
+        return self._raw_fields_cache
 
     @property
-    @lru_cache()
     def field_metas(self) -> List[Dict[str, str]]:
-        data = self.get_datas_by_sql("SELECT * FROM pygwalker_mid_table LIMIT 1")
-        return get_data_meta_type(data[0]) if data else []
+        if self._field_metas_cache is None:
+            data = self.get_datas_by_sql("SELECT * FROM pygwalker_mid_table LIMIT 1")
+            self._field_metas_cache = get_data_meta_type(data[0]) if data else []
+        return self._field_metas_cache
 
     def to_records(self, limit: Optional[int] = None) -> List[Dict[str, Any]]:
         df = self.df.limit(limit) if limit is not None else self.df

--- a/pygwalker/data_parsers/spark_parser.py
+++ b/pygwalker/data_parsers/spark_parser.py
@@ -1,4 +1,5 @@
 from typing import Any, Dict, List, Optional
+from threading import Lock
 import logging
 import io
 
@@ -41,26 +42,35 @@ class SparkDataFrameDataParser(BaseDataParser):
         self.other_params = other_params
         self._field_metas_cache = None
         self._raw_fields_cache = None
+        self._cache_lock = Lock()
 
     @property
     def raw_fields(self) -> List[Dict[str, str]]:
-        if self._raw_fields_cache is None:
-            pandas_parser = PandasDataFrameDataParser(
-                self.example_pandas_df,
-                self.field_specs,
-                self.infer_string_to_date,
-                self.infer_number_to_dimension,
-                self.other_params,
-            )
-            self._raw_fields_cache = pandas_parser.raw_fields
-        return self._raw_fields_cache
+        cache = self._raw_fields_cache
+        if cache is not None:
+            return cache
+        with self._cache_lock:
+            if self._raw_fields_cache is None:
+                pandas_parser = PandasDataFrameDataParser(
+                    self.example_pandas_df,
+                    self.field_specs,
+                    self.infer_string_to_date,
+                    self.infer_number_to_dimension,
+                    self.other_params,
+                )
+                self._raw_fields_cache = pandas_parser.raw_fields
+            return self._raw_fields_cache
 
     @property
     def field_metas(self) -> List[Dict[str, str]]:
-        if self._field_metas_cache is None:
-            data = self.get_datas_by_sql("SELECT * FROM pygwalker_mid_table LIMIT 1")
-            self._field_metas_cache = get_data_meta_type(data[0]) if data else []
-        return self._field_metas_cache
+        cache = self._field_metas_cache
+        if cache is not None:
+            return cache
+        with self._cache_lock:
+            if self._field_metas_cache is None:
+                data = self.get_datas_by_sql("SELECT * FROM pygwalker_mid_table LIMIT 1")
+                self._field_metas_cache = get_data_meta_type(data[0]) if data else []
+            return self._field_metas_cache
 
     def to_records(self, limit: Optional[int] = None) -> List[Dict[str, Any]]:
         df = self.df.limit(limit) if limit is not None else self.df

--- a/pygwalker/data_parsers/spark_parser.py
+++ b/pygwalker/data_parsers/spark_parser.py
@@ -1,5 +1,5 @@
 from typing import Any, Dict, List, Optional
-from threading import Lock
+from functools import cached_property
 import logging
 import io
 
@@ -40,37 +40,22 @@ class SparkDataFrameDataParser(BaseDataParser):
         self.infer_string_to_date = infer_string_to_date
         self.infer_number_to_dimension = infer_number_to_dimension
         self.other_params = other_params
-        self._field_metas_cache = None
-        self._raw_fields_cache = None
-        self._cache_lock = Lock()
 
-    @property
+    @cached_property
     def raw_fields(self) -> List[Dict[str, str]]:
-        cache = self._raw_fields_cache
-        if cache is not None:
-            return cache
-        with self._cache_lock:
-            if self._raw_fields_cache is None:
-                pandas_parser = PandasDataFrameDataParser(
-                    self.example_pandas_df,
-                    self.field_specs,
-                    self.infer_string_to_date,
-                    self.infer_number_to_dimension,
-                    self.other_params,
-                )
-                self._raw_fields_cache = pandas_parser.raw_fields
-            return self._raw_fields_cache
+        pandas_parser = PandasDataFrameDataParser(
+            self.example_pandas_df,
+            self.field_specs,
+            self.infer_string_to_date,
+            self.infer_number_to_dimension,
+            self.other_params,
+        )
+        return pandas_parser.raw_fields
 
-    @property
+    @cached_property
     def field_metas(self) -> List[Dict[str, str]]:
-        cache = self._field_metas_cache
-        if cache is not None:
-            return cache
-        with self._cache_lock:
-            if self._field_metas_cache is None:
-                data = self.get_datas_by_sql("SELECT * FROM pygwalker_mid_table LIMIT 1")
-                self._field_metas_cache = get_data_meta_type(data[0]) if data else []
-            return self._field_metas_cache
+        data = self.get_datas_by_sql("SELECT * FROM pygwalker_mid_table LIMIT 1")
+        return get_data_meta_type(data[0]) if data else []
 
     def to_records(self, limit: Optional[int] = None) -> List[Dict[str, Any]]:
         df = self.df.limit(limit) if limit is not None else self.df

--- a/tests/test_data_parsers.py
+++ b/tests/test_data_parsers.py
@@ -1,6 +1,9 @@
+import gc
 import os.path
+import pickle
 import subprocess
 import sys
+import weakref
 
 from sqlalchemy import create_engine
 import pandas as pd
@@ -11,6 +14,7 @@ import pytest
 from pygwalker.services.data_parsers import get_dataset_hash, get_parser
 from pygwalker.data_parsers.database_parser import Connector, DatabaseDataParser, text
 from pygwalker.data_parsers.database_parser import _check_view_sql
+from pygwalker.data_parsers.pandas_parser import PandasDataFrameDataParser
 from pygwalker.errors import ViewSqlSameColumnError
 
 datas = [
@@ -92,6 +96,29 @@ def test_get_parser_reports_supported_inputs_for_unsupported_dataset():
     assert "pyarrow.Table" in message
     assert "pygwalker.data_parsers.database_parser.Connector" in message
     assert "cloud dataset id string" in message
+
+
+@pytest.mark.parametrize("cached_property_name", ["raw_fields", "field_metas"])
+def test_pandas_parser_cached_properties_do_not_retain_parser_or_dataframe(cached_property_name):
+    def create_refs():
+        df = pd.DataFrame({"city": ["London", "Tokyo"], "value": [1, 2]})
+        parser = PandasDataFrameDataParser(df, [], True, True, {})
+        getattr(parser, cached_property_name)
+        return weakref.ref(parser), weakref.ref(df)
+
+    parser_ref, df_ref = create_refs()
+    gc.collect()
+
+    assert parser_ref() is None
+    assert df_ref() is None
+
+
+def test_pandas_parser_remains_picklable_after_cached_properties_are_loaded():
+    parser = PandasDataFrameDataParser(pd.DataFrame({"city": ["London"], "value": [1]}), [], True, True, {})
+    parser.raw_fields
+    parser.field_metas
+
+    pickle.dumps(parser)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- Preserve the original #724 commits from Lilo so the initial fix authorship is retained.
- Replace method-level `@lru_cache()` on data parser cached properties with per-instance `cached_property` in the final implementation.
- Add regression coverage proving pandas parser cached properties do not retain parser/DataFrame instances and that parsers remain picklable after cache loading.

## Root Cause

`functools.lru_cache` stores calls in the decorated function wrapper. For instance methods and properties, that cache key includes `self`, so parser instances are retained by the class-level cache after callers drop their references. Those parser instances keep their DataFrames alive, causing memory growth in long-running processes that parse many datasets.

## Notes

This PR carries forward the original work from #724, then adds a compatibility adjustment: the final implementation uses `cached_property` instead of storing a `threading.Lock` on parser instances, so parser pickling keeps working.

Supersedes #735.
Fixes #723.

## Validation

- `./venv/bin/python -m pytest tests/test_data_parsers.py -q`
- `./venv/bin/python -m pytest -q`
- `./venv/bin/python -m ruff check .`
