### PR TITLE
[codex] prepare 0.6 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,8 @@ html = walker.to_html()
 html = pyg.to_html(walker)
 ```
 
+See [PyGWalker 0.6 Release Notes](./docs/RELEASE_0_6.md) for the compatibility policy, deprecation timeline, and tested runtime support.
+
 After exploring in the UI, export the current chart state as reproducible Python code:
 
 ```python

--- a/docs/RELEASE_0_6.md
+++ b/docs/RELEASE_0_6.md
@@ -1,0 +1,41 @@
+# PyGWalker 0.6 Release Notes
+
+PyGWalker 0.6 introduces the new public computation model and the reusable `Walker` API while keeping the 0.5 user-facing computation flags available for compatibility.
+
+## API Direction
+
+Use `computation` to choose where queries run:
+
+```python
+pyg.walk(df, computation="auto")
+pyg.walk(df, computation="browser")
+pyg.walk(df, computation="kernel")
+pyg.walk(df, computation="cloud")
+```
+
+For code that renders the same data in more than one environment, prefer a reusable `Walker`:
+
+```python
+w = pyg.Walker(df, computation="kernel")
+w.show()
+w.to_html()
+w.to_streamlit()
+```
+
+`kernel_computation`, `cloud_computation`, and `use_kernel_calc` are deprecated in 0.6 but remain supported. They emit `DeprecationWarning` and are scheduled for removal in PyGWalker 0.7.0. Do not mix an explicit non-auto `computation` value with enabled legacy computation flags.
+
+## Jupyter Rendering
+
+The anywidget path is the preferred and default Jupyter rendering path. `Jupyter` and `JupyterWidget` remain accepted as legacy aliases in 0.6, but they warn and resolve to the anywidget transport. These aliases are scheduled for removal in PyGWalker 0.7.0.
+
+## Static HTML
+
+Static HTML export is browser-only. Exporting static HTML from `computation="kernel"` or `computation="cloud"` raises an error instead of producing output that cannot execute live kernel or cloud computation.
+
+## Privacy
+
+The default privacy mode is `update-only`. Event telemetry is sent only when privacy is set to `events`, and the frontend Segment tracker opens only for that `events` setting.
+
+## Tested Support
+
+The 0.6 release line is validated against Python 3.10, 3.11, 3.12, and 3.13. The frontend and publish workflows build with Node.js 22.x, and CI runs the frontend build plus Playwright smoke tests before packaging.

--- a/pygwalker/__init__.py
+++ b/pygwalker/__init__.py
@@ -10,7 +10,7 @@ from pygwalker.utils.execute_env_check import check_kaggle as __check_kaggle
 from pygwalker.services.global_var import GlobalVarManager
 from pygwalker.services.kaggle import show_tips_user_kaggle as __show_tips_user_kaggle
 
-__version__ = "0.5.0.1"
+__version__ = "0.6.0rc0"
 __hash__ = __rand_str()
 
 from pygwalker.api.adapter import walk, render, table

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,11 +92,11 @@ version = { path = "pygwalker/__init__.py" }
 
 [tool.hatch.build]
 include = [
-    "pygwalker",
-    "pygwalker_tools",
-    "bin",
-    "pygwalker/templates/**",
-    "pygwalker/templates/**/*",
+    "/pygwalker",
+    "/pygwalker_tools",
+    "/bin",
+    "/pygwalker/templates/**",
+    "/pygwalker/templates/**/*",
 ]
 exclude = [ "/graphic-walker", "/tests" ]
 artifacts = [ "pygwalker/templates/*" ]
@@ -124,14 +124,18 @@ build_cmd = "dev"
 [tool.hatch.build.targets.sdist]
 include = [
     "README.md", "LICENSE",
-    "app",
-    "pygwalker",
-    "pygwalker_tools",
-    "bin",
-    "pygwalker/templates/**",
-    "pygwalker/templates/**/*",
-    "scripts",
+    "/app",
+    "/pygwalker",
+    "/pygwalker_tools",
+    "/bin",
+    "/pygwalker/templates/**",
+    "/pygwalker/templates/**/*",
+    "/scripts",
 ]
+
+[tool.hatch.build.targets.sdist.force-include]
+"app/src/lib" = "app/src/lib"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -56,6 +56,7 @@ def test_publish_workflow_packages_fresh_frontend_bundle():
     workflow = (REPO_ROOT / ".github/workflows/publish.yml").read_text(encoding="utf-8")
 
     assert "node-version: [22.x]" in workflow
+    assert "workflow_dispatch:" in workflow
     assert "./scripts/compile.sh" in workflow
     assert "name: pygwalker-app" in workflow
     assert "path: ./pygwalker/templates/dist/*" in workflow
@@ -69,3 +70,4 @@ def test_publish_workflow_packages_fresh_frontend_bundle():
     download_dist_start = workflow.index("uses: actions/download-artifact@v4", build_py_start)
     build_package_start = workflow.index("python -m build .", build_py_start)
     assert download_dist_start < build_package_start
+    assert "github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags')" in workflow

--- a/tests/test_computation.py
+++ b/tests/test_computation.py
@@ -30,6 +30,22 @@ def test_resolve_computation_mode_rejects_enabled_legacy_flags_with_new_api():
         resolve_computation_mode(object(), computation="browser", kernel_computation=True)
 
 
+@pytest.mark.parametrize(
+    ("legacy_kwargs", "expected_message_fragment"),
+    [
+        ({"kernel_computation": True}, "kernel_computation"),
+        ({"cloud_computation": True}, "cloud_computation"),
+        ({"use_kernel_calc": True}, "use_kernel_calc"),
+    ],
+)
+def test_resolve_computation_mode_rejects_each_enabled_legacy_flag_with_new_api(
+    legacy_kwargs,
+    expected_message_fragment,
+):
+    with pytest.raises(ValueError, match=expected_message_fragment):
+        resolve_computation_mode(object(), computation="browser", **legacy_kwargs)
+
+
 def test_resolve_computation_mode_preserves_default_kernel_semantics():
     assert resolve_computation_mode(object(), default_kernel_computation=True) == (True, False)
 
@@ -37,3 +53,20 @@ def test_resolve_computation_mode_preserves_default_kernel_semantics():
 def test_resolve_computation_mode_warns_for_legacy_kernel_param():
     with pytest.warns(DeprecationWarning, match="kernel_computation.*0\\.7\\.0"):
         assert resolve_computation_mode(object(), kernel_computation=True) == (True, False)
+
+
+@pytest.mark.parametrize(
+    ("legacy_kwargs", "expected_result", "expected_warning"),
+    [
+        ({"kernel_computation": True}, (True, False), "kernel_computation.*0\\.7\\.0"),
+        ({"cloud_computation": True}, (False, True), "cloud_computation.*0\\.7\\.0"),
+        ({"use_kernel_calc": True}, (True, False), "use_kernel_calc.*0\\.7\\.0"),
+    ],
+)
+def test_resolve_computation_mode_warns_and_preserves_each_legacy_flag(
+    legacy_kwargs,
+    expected_result,
+    expected_warning,
+):
+    with pytest.warns(DeprecationWarning, match=expected_warning):
+        assert resolve_computation_mode(object(), **legacy_kwargs) == expected_result

--- a/tests/test_pygwalker_core.py
+++ b/tests/test_pygwalker_core.py
@@ -1305,6 +1305,7 @@ def test_pygwalker_open_in_desktop_callback_validates_payload(monkeypatch):
         ({"computation": "browser"}, False),
         ({"computation": "kernel"}, True),
         ({"computation": "cloud"}, False),
+        ({"cloud_computation": True}, False),
         ({"env": "JupyterConvert", "kernel_computation": False}, False),
     ],
 )
@@ -1322,7 +1323,8 @@ def test_jupyter_walk_sets_pygwalker_kernel_computation_mode(
     monkeypatch.setattr(PygWalker, "display_on_jupyter_use_widgets", lambda self: None)
     monkeypatch.setattr(PygWalker, "display_on_jupyter", lambda self: None)
     monkeypatch.setattr(PygWalker, "display_on_convert_html", lambda self: None)
-    cloud_uploads = _patch_cloud_computation_parser(monkeypatch) if kwargs.get("computation") == "cloud" else []
+    expects_cloud_computation = kwargs.get("computation") == "cloud" or kwargs.get("cloud_computation") is True
+    cloud_uploads = _patch_cloud_computation_parser(monkeypatch) if expects_cloud_computation else []
 
     with _expected_legacy_computation_warning(kwargs):
         walker = jupyter.walk(
@@ -1332,7 +1334,7 @@ def test_jupyter_walk_sets_pygwalker_kernel_computation_mode(
         )
 
     assert walker.kernel_computation is expected_kernel_computation
-    if kwargs.get("computation") == "cloud":
+    if expects_cloud_computation:
         assert walker.cloud_computation is True
         assert walker.dataset_type == "cloud_dataset"
         assert len(cloud_uploads) == 1

--- a/tests/test_pyproject_metadata.py
+++ b/tests/test_pyproject_metadata.py
@@ -1,5 +1,9 @@
 from pathlib import Path
 
+from packaging.version import Version
+
+import pygwalker
+
 
 def _extract_extra(pyproject_text: str, extra_name: str) -> list[str]:
     start = pyproject_text.index(f"{extra_name} = [")
@@ -31,6 +35,21 @@ def _extract_hatch_sdist_include(pyproject_text: str) -> list[str]:
     ]
 
 
+def _extract_sdist_force_include(pyproject_text: str) -> dict[str, str]:
+    section_start = pyproject_text.index("[tool.hatch.build.targets.sdist.force-include]")
+    section_end = pyproject_text.find("\n[", section_start + 1)
+    if section_end == -1:
+        section_end = len(pyproject_text)
+
+    entries = {}
+    for line in pyproject_text[section_start:section_end].splitlines()[1:]:
+        if not line.strip():
+            continue
+        source, target = line.split("=", maxsplit=1)
+        entries[source.strip().strip('"')] = target.strip().strip('"')
+    return entries
+
+
 def test_jupyter_notebook_extra_targets_modern_widgets_by_default():
     pyproject = (Path(__file__).resolve().parents[1] / "pyproject.toml").read_text(encoding="utf-8")
 
@@ -59,6 +78,16 @@ def test_project_metadata_declares_supported_python_and_bounded_dependencies():
     assert "pyarrow>=10,<25" in dependencies
 
 
+def test_release_version_is_derived_from_package_init():
+    repo_root = Path(__file__).resolve().parents[1]
+    pyproject = (repo_root / "pyproject.toml").read_text(encoding="utf-8")
+    parsed_version = Version(pygwalker.__version__)
+
+    assert 'dynamic = ["version"]' in pyproject
+    assert 'version = { path = "pygwalker/__init__.py" }' in pyproject
+    assert parsed_version.release == (0, 6, 0)
+
+
 def test_dev_extra_contains_ci_quality_tools():
     pyproject = (Path(__file__).resolve().parents[1] / "pyproject.toml").read_text(encoding="utf-8")
 
@@ -76,7 +105,7 @@ def test_package_declares_pep561_typed_marker():
     pyproject = (repo_root / "pyproject.toml").read_text(encoding="utf-8")
 
     assert (repo_root / "pygwalker/py.typed").is_file()
-    assert "pygwalker" in _extract_hatch_build_include(pyproject)
+    assert "/pygwalker" in _extract_hatch_build_include(pyproject)
 
 
 def test_public_dataframe_type_alias_includes_pyarrow_table():
@@ -93,5 +122,21 @@ def test_package_keeps_pygwalker_tools_metrics_namespace():
 
     assert (repo_root / "pygwalker_tools/metrics").is_dir()
     assert (repo_root / "tests/test_metrics_tools.py").is_file()
-    assert "pygwalker_tools" in _extract_hatch_build_include(pyproject)
-    assert "pygwalker_tools" in _extract_hatch_sdist_include(pyproject)
+    assert "/pygwalker_tools" in _extract_hatch_build_include(pyproject)
+    assert "/pygwalker_tools" in _extract_hatch_sdist_include(pyproject)
+
+
+def test_hatch_build_includes_root_bin_only():
+    repo_root = Path(__file__).resolve().parents[1]
+    pyproject = (repo_root / "pyproject.toml").read_text(encoding="utf-8")
+
+    assert "/bin" in _extract_hatch_build_include(pyproject)
+    assert "bin" not in _extract_hatch_build_include(pyproject)
+
+
+def test_sdist_force_includes_frontend_lib_alias_sources():
+    repo_root = Path(__file__).resolve().parents[1]
+    pyproject = (repo_root / "pyproject.toml").read_text(encoding="utf-8")
+
+    assert (repo_root / "app/src/lib/utils.ts").is_file()
+    assert _extract_sdist_force_include(pyproject)["app/src/lib"] == "app/src/lib"

--- a/tests/test_readme_api_reference.py
+++ b/tests/test_readme_api_reference.py
@@ -149,6 +149,30 @@ def test_readme_walk_api_table_marks_legacy_jupyter_envs_deprecated():
     assert "PyGWalker 0.7.0" in env_row["description"]
 
 
+def test_release_0_6_notes_cover_public_compatibility_promises():
+    release_note = (REPO_ROOT / "docs/RELEASE_0_6.md").read_text(encoding="utf-8")
+
+    required_fragments = [
+        'computation="browser"',
+        "reusable `Walker`",
+        "`kernel_computation`, `cloud_computation`, and `use_kernel_calc` are deprecated in 0.6 but remain supported",
+        "PyGWalker 0.7.0",
+        "anywidget path is the preferred and default Jupyter rendering path",
+        "Static HTML export is browser-only",
+        "default privacy mode is `update-only`",
+        "Python 3.10, 3.11, 3.12, and 3.13",
+        "Node.js 22.x",
+    ]
+    for fragment in required_fragments:
+        assert fragment in release_note
+
+
+def test_readme_links_to_0_6_release_notes():
+    readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+
+    assert "[PyGWalker 0.6 Release Notes](./docs/RELEASE_0_6.md)" in readme
+
+
 def test_translated_readmes_defer_api_reference_to_english_readme():
     docs_dir = Path(__file__).resolve().parents[1] / "docs"
 


### PR DESCRIPTION
## Summary

Prepare the PyGWalker 0.6 release line without removing deprecated 0.6-compatible APIs.

- Bump `pygwalker.__version__` to `0.6.0rc0`.
- Add `docs/RELEASE_0_6.md` with the public compatibility policy, computation API direction, anywidget-first Jupyter behavior, static HTML limits, privacy defaults, and tested runtime support.
- Link the 0.6 release notes from the README.
- Tighten release-readiness tests for legacy computation flags, public `cloud_computation=True` compatibility, version metadata, release notes, and publish workflow readiness.
- Fix packaging so wheel-from-sdist can rebuild the frontend and so wheel artifacts do not include frontend build-time `app/` or `node_modules` content.

## Root Cause / Packaging Fix

The release build surfaced two package hygiene issues:

- The sdist missed `app/src/lib`, because the repo-level Python `.gitignore` has a generic `lib/` pattern. The sdist now force-includes `app/src/lib`.
- The wheel-from-sdist build installed frontend dependencies, and the previous Hatch include pattern for `bin` could match nested `node_modules/*/bin` files. Build includes are now root-anchored.

## Validation

- `venv/bin/python -X faulthandler -W error::DeprecationWarning:pygwalker -m pytest -o faulthandler_timeout=300 tests` -> `317 passed`
- `ruff check pygwalker tests scripts bin pygwalker_tools`
- `ruff format --check pygwalker tests scripts bin pygwalker_tools`
- generated `app/src/interfaces/comm.generated.ts` freshness check
- `./scripts/compile.sh`
- `yarn playwright install chromium && yarn test:front_end` -> `1 passed`
- `venv/bin/python -m build .`
- `venv/bin/python -m twine check dist/*`
- Wheel inspection: includes `pygwalker/templates/dist/pygwalker-app.iife.js`; excludes `app/`, `node_modules`, tests, caches, `.DS_Store`, and old wheels.

## Independent Review

- Compatibility/package audit sub-agent reviewed the 0.6 gaps and identified the legacy computation flag symmetry and public cloud compatibility tests, both addressed here.
- Independent acceptance agent used the Codex Chrome Extension with real Chrome to open a locally generated PyGWalker page. The Graphic Walker UI rendered with `Data / Visualization`, fields, toolbar, and shelf drop zones visible, with no console errors or warnings.